### PR TITLE
Add “Experiencia CBM” section, header link and basic SEO/meta tags

### DIFF
--- a/src/app/core/header/header.html
+++ b/src/app/core/header/header.html
@@ -6,6 +6,7 @@
     </a>
 
     <nav class="nav-links">
+      <a href="#experiencia">Experiencia</a>
       <a href="#servicios">Tratamientos</a>
       <a href="#reserva">Pedir cita</a>
       <a href="#contacto">Contáctanos</a>

--- a/src/app/features/home/home-page/home-page.css
+++ b/src/app/features/home/home-page/home-page.css
@@ -125,6 +125,53 @@
 }
 
 
+.experience{
+  background: linear-gradient(180deg, #ffffff 0%, #f8f3ff 100%);
+}
+
+.experience-track{
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+
+.experience-step{
+  position: relative;
+  background: #fff;
+  border: 1px solid #ebdbff;
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: 0 10px 28px rgba(41, 22, 73, 0.08);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.experience-step:hover{
+  transform: translateY(-6px);
+  box-shadow: 0 18px 34px rgba(41, 22, 73, 0.14);
+}
+
+.experience-step-number{
+  margin: 0 0 10px;
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  color: #7b4dff;
+  font-weight: 800;
+}
+
+.experience-step h3{
+  margin: 0 0 10px;
+  font-size: 24px;
+  color: #1f1b2d;
+}
+
+.experience-step p{
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.65;
+  color: #575161;
+}
+
+
 .quick-benefits{
   padding-top: 20px;
 }
@@ -314,6 +361,10 @@
     grid-template-columns: repeat(2, 1fr);
   }
 
+  .experience-track{
+    grid-template-columns: 1fr;
+  }
+
   .services-grid{
     grid-template-columns: 1fr;
   }
@@ -408,6 +459,10 @@
 
   .mid-cta h2{
     font-size: 28px;
+  }
+
+  .experience-step h3{
+    font-size: 22px;
   }
 
   .services-grid{

--- a/src/app/features/home/home-page/home-page.html
+++ b/src/app/features/home/home-page/home-page.html
@@ -70,6 +70,48 @@
   </div>
 </section>
 
+<section id="experiencia" class="experience section">
+  <div class="container">
+    <div class="section-heading" appRevealOnScroll>
+      <p class="section-tag">Experiencia CBM</p>
+      <h2>Un camino de recuperación que también se siente</h2>
+      <p class="section-description">
+        No solo tratamos el dolor: te guiamos paso a paso para que recuperes confianza,
+        seguridad y ganas de volver a moverte.
+      </p>
+    </div>
+
+    <div class="experience-track">
+      <article class="experience-step reveal-delay-1" appRevealOnScroll>
+        <span class="experience-step-number">01</span>
+        <h3>Te escuchamos de verdad</h3>
+        <p>
+          Empezamos con tu historia y tus objetivos. Queremos entender qué te preocupa y qué
+          necesitas para volver a sentirte bien.
+        </p>
+      </article>
+
+      <article class="experience-step reveal-delay-2" appRevealOnScroll>
+        <span class="experience-step-number">02</span>
+        <h3>Diseñamos tu plan personal</h3>
+        <p>
+          Creamos una estrategia clara y realista para tu caso, con sesiones y ejercicios adaptados
+          a tu ritmo.
+        </p>
+      </article>
+
+      <article class="experience-step reveal-delay-3" appRevealOnScroll>
+        <span class="experience-step-number">03</span>
+        <h3>Acompañamiento cercano</h3>
+        <p>
+          Te acompañamos en cada avance para que recuperes movilidad con tranquilidad y confianza en
+          tu cuerpo.
+        </p>
+      </article>
+    </div>
+  </div>
+</section>
+
 
 <section id="servicios" class="services section">
   <div class="container">

--- a/src/index.html
+++ b/src/index.html
@@ -1,10 +1,21 @@
 <!doctype html>
-<html lang="en">
+<html lang="es">
 <head>
   <meta charset="utf-8">
-  <title>CBM Fisioterapia | Terrassa</title>
+  <title>CBM Fisioterapia en Terrassa | Recupera tu bienestar</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="CBM Fisioterapia en Terrassa: tratamiento personalizado, fisioterapia, pilates terapéutico y acompañamiento cercano para recuperar movilidad y bienestar.">
+  <meta name="keywords" content="fisioterapia terrassa, pilates terapéutico, rehabilitación, dolor espalda, cbm fisioterapia">
+  <meta name="robots" content="index, follow">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="CBM Fisioterapia en Terrassa | Recupera tu bienestar">
+  <meta property="og:description" content="Atención cercana y tratamientos personalizados para aliviar dolor y mejorar tu movilidad.">
+  <meta property="og:image" content="/hero-fisio.jpg">
+  <meta property="og:locale" content="es_ES">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="CBM Fisioterapia en Terrassa | Recupera tu bienestar">
+  <meta name="twitter:description" content="Centro de fisioterapia en Terrassa con enfoque humano y plan de recuperación personalizado.">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Hacer la navegación de la home más emocional y visual para enganchar a pacientes y reforzar el storytelling del centro. 
- Mejorar señales básicas de SEO y localización para aumentar la relevancia en búsquedas locales.

### Description
- Añadida la sección `Experiencia CBM` en `src/app/features/home/home-page/home-page.html` con una narrativa en 3 pasos (escucha, plan, acompañamiento). 
- Añadidos estilos visuales y responsivos en `src/app/features/home/home-page/home-page.css` (`.experience`, `.experience-track`, `.experience-step`, etc.) para tarjetas, hover y diseño móvil. 
- Insertado el enlace `Experiencia` en el menú principal en `src/app/core/header/header.html` para dar acceso directo desde la cabecera. 
- Actualizado `src/index.html` para usar `lang=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b04ad303a0832896551c2c515293c3)