### PR TITLE
Corregir enlace de 'Política de cookies' en footer para usar routerLink

### DIFF
--- a/src/app/core/footer/footer.html
+++ b/src/app/core/footer/footer.html
@@ -36,7 +36,7 @@
         <li><a href="https://www.google.com/search?q=CBM+Fisioterapia+Terrassa" target="_blank" rel="noopener noreferrer">Reseñas</a></li>
         <li><a href="https://www.instagram.com/cbm.fisioterapia/" target="_blank" rel="noopener noreferrer">Instagram</a></li>
         <li><a href="https://www.google.com/maps/search/?api=1&query=Calle+Arquimedes+227+Terrassa" target="_blank" rel="noopener noreferrer">Cómo llegar</a></li>
-        <li><a href="/cookies">Política de cookies</a></li>
+        <li><a routerLink="/cookies">Política de cookies</a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
### Motivation
- Evitar problemas de navegación en móvil al mantener la navegación dentro del router de la SPA en lugar de usar un `href` que provoca recargas o comportamiento inesperado.

### Description
- Reemplacé el enlace en `src/app/core/footer/footer.html` de `<a href="/cookies">` a `<a routerLink="/cookies">` para usar el enrutador de Angular.

### Testing
- Ejecuté `npm run build` y la compilación finalizó correctamente.
- Ejecuté un script de Playwright en un viewport móvil que abrió la página principal y pulsó el enlace del footer, y la navegación a ` /cookies` se completó con éxito (captura generada).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b198f7d8408328abd9a0af093a669f)