### PR TITLE
Use Angular `routerLink` for cookies page and import `RouterLink` in FooterComponent

### DIFF
--- a/src/app/core/footer/footer.html
+++ b/src/app/core/footer/footer.html
@@ -36,7 +36,7 @@
         <li><a href="https://www.google.com/search?q=CBM+Fisioterapia+Terrassa" target="_blank" rel="noopener noreferrer">Reseñas</a></li>
         <li><a href="https://www.instagram.com/cbm.fisioterapia/" target="_blank" rel="noopener noreferrer">Instagram</a></li>
         <li><a href="https://www.google.com/maps/search/?api=1&query=Calle+Arquimedes+227+Terrassa" target="_blank" rel="noopener noreferrer">Cómo llegar</a></li>
-        <li><a href="/cookies">Política de cookies</a></li>
+        <li><a routerLink="/cookies">Política de cookies</a></li>
       </ul>
     </div>
 

--- a/src/app/core/footer/footer.ts
+++ b/src/app/core/footer/footer.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-footer',
   standalone: true,
-  imports: [],
+  imports: [RouterLink],
   templateUrl: './footer.html',
   styleUrls: ['./footer.css']
 })


### PR DESCRIPTION
### Motivation
- Replace a plain anchor with Angular navigation to enable in-app routing for the cookies page and avoid full page reloads in the standalone footer component.

### Description
- Updated `footer.html` to use `<a routerLink="/cookies">` instead of a raw `href` to integrate with the router.
- Added `RouterLink` import from `@angular/router` and added it to the standalone `FooterComponent` `imports` array so the template directive is available.

### Testing
- Ran `ng build` to validate compilation and `ng lint` to validate formatting and imports; both completed successfully.
- Ran unit tests with `ng test`; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b198f7d8408328abd9a0af093a669f)