### PR TITLE
feat(hero): integrar video local como fondo con fallback responsive y overlay

### DIFF
--- a/src/app/features/home/home-page/home-page.css
+++ b/src/app/features/home/home-page/home-page.css
@@ -1,6 +1,6 @@
 .hero{
   position: relative;
-  overflow: hidden;
+  overflow: clip;
   padding: 116px 0 86px;
   background: linear-gradient(180deg, rgba(255, 247, 251, 0.74) 0%, rgba(255, 255, 255, 0.38) 100%);
 }
@@ -96,8 +96,20 @@
   position: relative;
   border-radius: 30px;
   overflow: hidden;
-  border: 1px solid rgba(255,255,255,0.7);
+  border: 1px solid rgba(255,255,255,0.68);
   box-shadow: 0 28px 56px rgba(31, 27, 45, 0.16);
+  isolation: isolate;
+}
+
+.hero-image-card::before{
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 18% 20%, rgba(255, 79, 163, 0.22) 0%, transparent 48%),
+              radial-gradient(circle at 84% 82%, rgba(123, 77, 255, 0.24) 0%, transparent 52%);
+  z-index: 2;
+  mix-blend-mode: screen;
+  pointer-events: none;
 }
 
 .hero-image-card::after{
@@ -106,22 +118,44 @@
   inset: 0;
   background: linear-gradient(
     180deg,
-    rgba(255,255,255,0.05) 0%,
-    rgba(0,0,0,0.08) 100%
+    rgba(19, 15, 33, 0.18) 0%,
+    rgba(19, 15, 33, 0.42) 100%
   );
+  z-index: 3;
   pointer-events: none;
 }
 
-.hero-image-card img{
+.hero-media{
   width: 100%;
   height: 560px;
   object-fit: cover;
   display: block;
-  transition: transform 0.6s ease;
 }
 
-.hero-image-card:hover img{
-  transform: scale(1.05);
+.hero-video{
+  position: relative;
+  z-index: 1;
+  transition: transform 0.7s ease;
+}
+
+.hero-image-card:hover .hero-video{
+  transform: scale(1.04);
+}
+
+.hero-image-fallback{
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+@media (max-width: 768px), (prefers-reduced-motion: reduce){
+  .hero-video{
+    display: none;
+  }
+
+  .hero-image-fallback{
+    z-index: 1;
+  }
 }
 
 .services{
@@ -393,7 +427,7 @@
     font-size: 32px;
   }
 
-  .hero-image-card img{
+  .hero-media{
     height: 410px;
   }
 }
@@ -453,7 +487,7 @@
     order: -1;
   }
 
-  .hero-image-card img{
+  .hero-media{
     height: 320px;
   }
 

--- a/src/app/features/home/home-page/home-page.html
+++ b/src/app/features/home/home-page/home-page.html
@@ -33,7 +33,20 @@
 
     <div class="hero-image reveal-delay-2" appRevealOnScroll>
       <div class="hero-image-card">
-        <img src="/hero-fisio.jpg" alt="CBM Fisioterapia">
+        <video
+          class="hero-media hero-video"
+          autoplay
+          muted
+          loop
+          playsinline
+          preload="metadata"
+          poster="/hero-fisio.jpg"
+          aria-label="Video del centro CBM Fisioterapia"
+        >
+          <source src="/fondo-fisio.mp4" type="video/mp4">
+        </video>
+
+        <img class="hero-media hero-image-fallback" src="/hero-fisio.jpg" alt="CBM Fisioterapia">
       </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Integrar el video hero ya generado como fondo principal sin perder la identidad visual ni las animaciones existentes. 
- Mejorar contraste y legibilidad del texto sobre el video manteniendo la paleta y la estética premium. 

### Description
- Reemplacé la imagen principal del hero por un bloque multimedia que incluye un `<video>` local (`/fondo-fisio.mp4`) con `autoplay`, `muted`, `loop`, `playsinline`, `preload="metadata"` y `poster` y añadí una imagen fallback (`/hero-fisio.jpg`) en el mismo contenedor; archivo modificado: `src/app/features/home/home-page/home-page.html`.
- Añadí clases y reglas CSS para `hero-media`, `hero-video` y `hero-image-fallback` y mantuve `object-fit: cover` para conservar encuadre; archivo modificado: `src/app/features/home/home-page/home-page.css`.
- Integré la estética actual usando pseudo-elementos en la card del hero (`::before` glow radial y `::after` overlay oscuro) y ajuste de `z-index`/`isolation` para combinar el video con las decoraciones sin romper la identidad visual.
- Implementé comportamiento responsive y accesible: en pantallas `<=768px` y cuando `prefers-reduced-motion: reduce` se oculta el video y se muestra el fallback para mejorar rendimiento y encuadre; además ajusté las alturas del media en tablet/mobile y cambié `overflow: hidden` a `overflow: clip` en `.hero` para reducir riesgos de desborde horizontal.

### Testing
- Ejecuté `npm run build` y la compilación finalizó correctamente (build OK).
- Levanté la app con `npm run start -- --host 0.0.0.0 --port 4200` para validación visual y el servidor respondió correctamente (dev server running).
- Capturé comprobaciones visuales automáticas con Playwright (screenshots desktop/mobile) para verificar la integración y la legibilidad del texto sobre el video, y las capturas se generaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19d1da2d88328bcce2cc76713346f)