### PR TITLE
Refine background motion and premium micro-animations

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -9,56 +9,96 @@
   pointer-events: none;
   overflow: hidden;
   background:
-    radial-gradient(circle at 15% 20%, rgba(255, 79, 163, 0.14), transparent 45%),
-    radial-gradient(circle at 85% 15%, rgba(123, 77, 255, 0.16), transparent 48%),
-    radial-gradient(circle at 50% 82%, rgba(70, 199, 232, 0.14), transparent 52%),
-    linear-gradient(180deg, #fffafc 0%, #ffffff 60%, #fffdf6 100%);
+    radial-gradient(circle at 12% 18%, rgba(255, 79, 163, 0.12), transparent 48%),
+    radial-gradient(circle at 88% 12%, rgba(123, 77, 255, 0.14), transparent 52%),
+    radial-gradient(circle at 52% 86%, rgba(70, 199, 232, 0.1), transparent 54%),
+    linear-gradient(180deg, #fffafc 0%, #ffffff 62%, #fffdf6 100%);
 }
 
 .physio-wave,
 .physio-orbit,
 .physio-dot,
-.physio-ribbon {
+.physio-ribbon,
+.physio-aurora {
   position: absolute;
 }
 
+.physio-aurora {
+  border-radius: 50%;
+  filter: blur(90px);
+  mix-blend-mode: screen;
+  opacity: 0.34;
+}
+
+.physio-aurora-1 {
+  width: min(48vw, 650px);
+  height: min(48vw, 650px);
+  top: -18vh;
+  left: -12vw;
+  background: radial-gradient(circle, rgba(255, 79, 163, 0.28) 0%, rgba(255, 79, 163, 0) 72%);
+  transform: translateY(calc(var(--scroll-progress) * -14vh));
+  animation: breathe-aurora-1 26s ease-in-out infinite;
+}
+
+.physio-aurora-2 {
+  width: min(42vw, 560px);
+  height: min(42vw, 560px);
+  right: -10vw;
+  top: 40vh;
+  background: radial-gradient(circle, rgba(123, 77, 255, 0.3) 0%, rgba(123, 77, 255, 0) 74%);
+  transform: translateY(calc(var(--scroll-progress) * -22vh));
+  animation: breathe-aurora-2 32s ease-in-out infinite;
+}
+
 .physio-wave {
-  inset: -24% -20%;
+  inset: -28% -24%;
   background:
     repeating-radial-gradient(
-      circle at 50% 50%,
-      rgba(123, 77, 255, 0.12) 0 2px,
-      rgba(123, 77, 255, 0) 2px 28px
+      ellipse at 50% 50%,
+      rgba(123, 77, 255, 0.08) 0 1.5px,
+      rgba(123, 77, 255, 0) 1.5px 24px
     );
-  opacity: 0.28;
-  transform: translateY(calc(var(--scroll-progress) * -18vh));
-  animation: breathe-wave 14s ease-in-out infinite;
+  opacity: 0.24;
+  transform: translateY(calc(var(--scroll-progress) * -14vh));
+  animation: breathe-wave 22s ease-in-out infinite;
+}
+
+.physio-wave-secondary {
+  inset: -36% -26%;
+  opacity: 0.14;
+  background:
+    repeating-radial-gradient(
+      ellipse at 46% 56%,
+      rgba(255, 79, 163, 0.09) 0 1px,
+      rgba(255, 79, 163, 0) 1px 28px
+    );
+  transform: translateY(calc(var(--scroll-progress) * -10vh));
+  animation: breathe-wave-secondary 30s ease-in-out infinite;
 }
 
 .physio-orbit {
-  border: 2px solid rgba(255, 79, 163, 0.2);
+  border: 1.5px solid rgba(255, 79, 163, 0.15);
   border-radius: 999px;
-  transform-style: preserve-3d;
 }
 
 .physio-orbit-1 {
-  width: min(42vw, 520px);
-  height: min(42vw, 520px);
-  left: -10vw;
-  top: 26vh;
-  border-color: rgba(255, 79, 163, 0.24);
-  transform: translateY(calc(var(--scroll-progress) * -24vh)) rotate(15deg);
-  animation: rotate-orbit 25s linear infinite;
+  width: min(40vw, 520px);
+  height: min(40vw, 520px);
+  left: -9vw;
+  top: 28vh;
+  border-color: rgba(255, 79, 163, 0.18);
+  transform: translateY(calc(var(--scroll-progress) * -20vh)) rotate(12deg);
+  animation: rotate-orbit 70s linear infinite;
 }
 
 .physio-orbit-2 {
-  width: min(34vw, 420px);
-  height: min(34vw, 420px);
+  width: min(33vw, 420px);
+  height: min(33vw, 420px);
   right: -8vw;
-  top: 60vh;
-  border-color: rgba(70, 199, 232, 0.3);
-  transform: translateY(calc(var(--scroll-progress) * -30vh)) rotate(-22deg);
-  animation: rotate-orbit-reverse 30s linear infinite;
+  top: 62vh;
+  border-color: rgba(70, 199, 232, 0.2);
+  transform: translateY(calc(var(--scroll-progress) * -24vh)) rotate(-18deg);
+  animation: rotate-orbit-reverse 84s linear infinite;
 }
 
 .physio-dot {
@@ -67,23 +107,36 @@
 }
 
 .physio-dot-1 {
-  width: 36px;
-  height: 36px;
-  left: 22vw;
-  top: 42vh;
-  background: rgba(255, 79, 163, 0.4);
-  transform: translateY(calc(var(--scroll-progress) * -28vh));
-  animation: float-dot 8s ease-in-out infinite;
+  width: 34px;
+  height: 34px;
+  left: 20vw;
+  top: 40vh;
+  background: rgba(255, 79, 163, 0.28);
+  transform: translateY(calc(var(--scroll-progress) * -22vh));
+  animation: float-dot 14s ease-in-out infinite;
 }
 
 .physio-dot-2 {
-  width: 28px;
-  height: 28px;
-  right: 18vw;
-  top: 24vh;
-  background: rgba(123, 77, 255, 0.35);
-  transform: translateY(calc(var(--scroll-progress) * -34vh));
-  animation: float-dot 10s ease-in-out infinite reverse;
+  width: 26px;
+  height: 26px;
+  right: 16vw;
+  top: 22vh;
+  background: rgba(123, 77, 255, 0.26);
+  transform: translateY(calc(var(--scroll-progress) * -26vh));
+  animation: float-dot 16s ease-in-out infinite reverse;
+}
+
+.physio-ribbon {
+  width: min(118vw, 1450px);
+  height: 220px;
+  left: -10vw;
+  top: 36vh;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 79, 163, 0.1), rgba(123, 77, 255, 0.08), rgba(70, 199, 232, 0.09));
+  filter: blur(34px);
+  opacity: 0.38;
+  transform: translateY(calc(var(--scroll-progress) * -34vh)) rotate(-7deg);
+  animation: drift-ribbon 34s ease-in-out infinite;
 }
 
 .app-content {
@@ -98,30 +151,51 @@
   flex: 1;
 }
 
-.physio-ribbon {
-  position: absolute;
-  width: min(120vw, 1500px);
-  height: 220px;
-  left: -12vw;
-  top: 38vh;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(255, 79, 163, 0.12), rgba(123, 77, 255, 0.1), rgba(70, 199, 232, 0.12));
-  filter: blur(34px);
-  opacity: 0.45;
-  transform: translateY(calc(var(--scroll-progress) * -42vh)) rotate(-8deg);
-  animation: drift-ribbon 22s ease-in-out infinite;
-}
-
-
 @keyframes breathe-wave {
   0%,
   100% {
-    opacity: 0.16;
-    transform: scale(1) translateY(calc(var(--scroll-progress) * -10vh));
+    opacity: 0.2;
+    transform: translateY(calc(var(--scroll-progress) * -14vh)) scale(1);
   }
   50% {
     opacity: 0.28;
-    transform: scale(1.07) translateY(calc(var(--scroll-progress) * -10vh));
+    transform: translateY(calc(var(--scroll-progress) * -14vh)) scale(1.04);
+  }
+}
+
+@keyframes breathe-wave-secondary {
+  0%,
+  100% {
+    opacity: 0.1;
+    transform: translateY(calc(var(--scroll-progress) * -10vh)) scale(1);
+  }
+  50% {
+    opacity: 0.18;
+    transform: translateY(calc(var(--scroll-progress) * -10vh)) scale(1.05);
+  }
+}
+
+@keyframes breathe-aurora-1 {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: translateY(calc(var(--scroll-progress) * -14vh)) scale(1);
+  }
+  50% {
+    opacity: 0.42;
+    transform: translateY(calc(var(--scroll-progress) * -14vh)) scale(1.07);
+  }
+}
+
+@keyframes breathe-aurora-2 {
+  0%,
+  100% {
+    opacity: 0.26;
+    transform: translateY(calc(var(--scroll-progress) * -22vh)) scale(1);
+  }
+  50% {
+    opacity: 0.38;
+    transform: translateY(calc(var(--scroll-progress) * -22vh)) scale(1.06);
   }
 }
 
@@ -146,12 +220,12 @@
 @keyframes drift-ribbon {
   0%,
   100% {
-    opacity: 0.36;
-    transform: translateY(calc(var(--scroll-progress) * -42vh)) rotate(-8deg) scaleX(1);
+    opacity: 0.32;
+    transform: translateY(calc(var(--scroll-progress) * -34vh)) rotate(-7deg) scaleX(1);
   }
   50% {
-    opacity: 0.54;
-    transform: translateY(calc(var(--scroll-progress) * -42vh)) rotate(-5deg) scaleX(1.06);
+    opacity: 0.46;
+    transform: translateY(calc(var(--scroll-progress) * -34vh)) rotate(-5deg) scaleX(1.05);
   }
 }
 
@@ -161,43 +235,59 @@
     translate: 0 0;
   }
   50% {
-    translate: 0 -18px;
+    translate: 0 -10px;
   }
 }
 
 @media (max-width: 768px) {
   .physio-wave {
-    opacity: 0.18;
+    opacity: 0.16;
+  }
+
+  .physio-wave-secondary {
+    opacity: 0.11;
   }
 
   .physio-orbit-1 {
-    width: 64vw;
-    height: 64vw;
-    left: -24vw;
+    width: 62vw;
+    height: 62vw;
+    left: -22vw;
     top: 34vh;
   }
 
   .physio-orbit-2 {
-    width: 54vw;
-    height: 54vw;
+    width: 52vw;
+    height: 52vw;
     right: -20vw;
     top: 68vh;
   }
 
   .physio-dot-1 {
-    left: 16vw;
-    top: 46vh;
+    left: 14vw;
+    top: 47vh;
   }
 
   .physio-dot-2 {
     right: 10vw;
-    top: 30vh;
+    top: 32vh;
   }
 
   .physio-ribbon {
     top: 52vh;
-    left: -30vw;
-    width: 160vw;
-    opacity: 0.35;
+    left: -28vw;
+    width: 155vw;
+    opacity: 0.32;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .physio-wave,
+  .physio-wave-secondary,
+  .physio-orbit,
+  .physio-dot,
+  .physio-ribbon,
+  .physio-aurora {
+    animation: none;
+    transform: none;
   }
 }

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,5 +1,8 @@
 <div class="physio-background" aria-hidden="true">
+  <div class="physio-aurora physio-aurora-1"></div>
+  <div class="physio-aurora physio-aurora-2"></div>
   <div class="physio-wave"></div>
+  <div class="physio-wave physio-wave-secondary"></div>
   <div class="physio-orbit physio-orbit-1"></div>
   <div class="physio-orbit physio-orbit-2"></div>
   <div class="physio-dot physio-dot-1"></div>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { Header } from './core/header/header';
 import { FooterComponent } from './core/footer/footer';
@@ -12,14 +12,32 @@ import { CookieConsentComponent } from './core/cookie-consent/cookie-consent';
   templateUrl: './app.html',
   styleUrls: ['./app.css']
 })
-export class App implements OnInit {
+export class App implements OnInit, OnDestroy {
+  private rafId: number | null = null;
+  private readonly onScroll = (): void => this.scheduleScrollProgressUpdate();
+
   ngOnInit(): void {
+    window.addEventListener('scroll', this.onScroll, { passive: true });
     this.updateScrollProgress();
   }
 
-  @HostListener('window:scroll')
-  onWindowScroll(): void {
-    this.updateScrollProgress();
+  ngOnDestroy(): void {
+    window.removeEventListener('scroll', this.onScroll);
+
+    if (this.rafId !== null) {
+      window.cancelAnimationFrame(this.rafId);
+    }
+  }
+
+  private scheduleScrollProgressUpdate(): void {
+    if (this.rafId !== null) {
+      return;
+    }
+
+    this.rafId = window.requestAnimationFrame(() => {
+      this.rafId = null;
+      this.updateScrollProgress();
+    });
   }
 
   private updateScrollProgress(): void {

--- a/src/app/shared/directives/reveal-on-scroll.directive.ts
+++ b/src/app/shared/directives/reveal-on-scroll.directive.ts
@@ -12,6 +12,7 @@ import {
 })
 export class RevealOnScrollDirective implements AfterViewInit, OnDestroy {
   private observer?: IntersectionObserver;
+  private readonly reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   constructor(
     private el: ElementRef<HTMLElement>,
@@ -19,6 +20,11 @@ export class RevealOnScrollDirective implements AfterViewInit, OnDestroy {
   ) {}
 
   ngAfterViewInit(): void {
+    if (this.reducedMotion) {
+      this.renderer.addClass(this.el.nativeElement, 'is-visible');
+      return;
+    }
+
     this.renderer.addClass(this.el.nativeElement, 'reveal');
 
     this.observer = new IntersectionObserver(
@@ -31,7 +37,8 @@ export class RevealOnScrollDirective implements AfterViewInit, OnDestroy {
         });
       },
       {
-        threshold: 0.15
+        threshold: 0.2,
+        rootMargin: '0px 0px -8% 0px'
       }
     );
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -81,13 +81,13 @@ img{
   font-weight:600;
   cursor:pointer;
   box-shadow: 0 10px 22px rgba(123, 77, 255, 0.24);
-  transition:transform 0.2s ease, opacity 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.28s ease, box-shadow 0.35s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .btn-primary:hover{
-  transform:translateY(-2px);
+  transform: translateY(-3px);
   opacity:0.96;
-  box-shadow: 0 14px 28px rgba(123, 77, 255, 0.28);
+  box-shadow: 0 16px 30px rgba(123, 77, 255, 0.3);
 }
 
 .btn-secondary{
@@ -101,13 +101,15 @@ img{
   background:var(--color-white);
   text-decoration:none;
   font-weight:600;
-  transition:all 0.2s ease;
+  transition: transform 0.32s cubic-bezier(0.22, 1, 0.36, 1), background-color 0.28s ease, border-color 0.28s ease, box-shadow 0.32s cubic-bezier(0.22, 1, 0.36, 1), color 0.2s ease;
 }
 
 .btn-secondary:hover{
+  transform: translateY(-2px);
   background: rgba(255, 79, 163, 0.08);
   color: var(--color-primary);
   border-color: var(--color-primary);
+  box-shadow: 0 12px 24px rgba(31, 27, 45, 0.08);
 }
 
 .section-flow{
@@ -137,20 +139,20 @@ img{
 .service-link,
 .issue-chip,
 .experience-step{
-  transition: transform 0.28s ease, box-shadow 0.28s ease, border-color 0.28s ease, color 0.2s ease, background-color 0.2s ease;
+  transition: transform 0.34s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.34s cubic-bezier(0.22, 1, 0.36, 1), border-color 0.3s ease, color 0.24s ease, background-color 0.24s ease;
 }
 
 .benefit-item:hover,
 .service-card:hover,
 .testimonial-card:hover,
 .hero-trust span:hover{
-  transform: translateY(-4px);
+  transform: translateY(-5px);
 }
 
 .benefit-item:hover,
 .service-card:hover,
 .testimonial-card:hover{
-  box-shadow: 0 18px 34px rgba(31, 27, 45, 0.11);
+  box-shadow: 0 20px 38px rgba(31, 27, 45, 0.12);
 }
 
 .benefit-icon,
@@ -186,6 +188,8 @@ img{
   .testimonial-card:hover,
   .hero-trust span:hover,
   .service-link:hover,
+  .btn-secondary:hover,
+  .social-btn:hover,
   .benefit-item:hover .benefit-icon,
   .service-card:hover .service-icon,
   .testimonial-card:hover .testimonial-avatar{
@@ -215,10 +219,19 @@ img{
   .testimonial-card:hover,
   .hero-trust span:hover,
   .service-link:hover,
+  .btn-secondary:hover,
+  .social-btn:hover,
   .benefit-item:hover .benefit-icon,
   .service-card:hover .service-icon,
   .testimonial-card:hover .testimonial-avatar{
     transform: none;
+  }
+
+  .reveal{
+    opacity: 1;
+    transform: none;
+    filter: none;
+    transition: none;
   }
 }
 
@@ -243,16 +256,19 @@ html{
 
 .reveal{
   opacity: 0;
-  transform: translateY(32px);
+  transform: translate3d(0, 26px, 0) scale(0.99);
+  filter: blur(4px);
   transition:
-    opacity 0.7s ease,
-    transform 0.7s ease;
-  will-change: opacity, transform;
+    opacity 0.72s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.78s cubic-bezier(0.22, 1, 0.36, 1),
+    filter 0.78s ease;
+  will-change: opacity, transform, filter;
 }
 
 .reveal.is-visible{
   opacity: 1;
-  transform: translateY(0);
+  transform: translate3d(0, 0, 0) scale(1);
+  filter: blur(0);
 }
 
 .reveal-delay-1{
@@ -265,6 +281,14 @@ html{
 
 .reveal-delay-3{
   transition-delay: 0.3s;
+}
+
+.reveal-delay-4{
+  transition-delay: 0.4s;
+}
+
+.reveal-delay-5{
+  transition-delay: 0.5s;
 }
 
 .social-floating{
@@ -286,7 +310,7 @@ html{
   justify-content: center;
   box-shadow: 0 6px 18px rgba(0,0,0,0.15);
   background: white;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.32s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.32s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .social-btn img{
@@ -295,8 +319,8 @@ html{
 }
 
 .social-btn:hover{
-  transform: translateY(-3px);
-  box-shadow: 0 10px 24px rgba(0,0,0,0.2);
+  transform: translateY(-4px);
+  box-shadow: 0 12px 26px rgba(0,0,0,0.2);
 }
 
 .instagram{


### PR DESCRIPTION
### Motivation
- Elevar la sensación premium de la web manteniendo la paleta rosa/violeta y el concepto del fondo animado respiratorio actual. 
- Añadir microanimaciones más elegantes y coherentes sin romper la legibilidad, el rendimiento ni la identidad clínica/wellness. 
- Mejorar la estabilidad del scroll/animaciones y respetar `prefers-reduced-motion` para accesibilidad.

### Description
- Evolved el fondo animado añadiendo capas de "aurora" radiales, una segunda onda radial lenta, orbits suaves, dots flotantes y un ribbon difuso en `src/app/app.html` y `src/app/app.css` para una respiración visual muy lenta y sutil. 
- Implementé throttling de actualizaciones de progreso de scroll usando `requestAnimationFrame` y listener pasivo en `src/app/app.ts` para reducir jank y mantener la ligera sensación de parallax mediante `--scroll-progress`. 
- Refiné las microinteracciones y timing en `src/styles.css` (easing más suave, sombras/elevación sutil, tiempos ligeramente alargados) y añadí utilidades de stagger (`.reveal-delay-4/5`). 
- Mejoré el reveal-on-scroll con fade + leve desplazamiento vertical + blur inicial y añadí handling de `prefers-reduced-motion` en el directive `src/app/shared/directives/reveal-on-scroll.directive.ts` (se salta animaciones si el usuario lo prefiere). 
- Mantengo exactamente la paleta y la estructura existente; los cambios son evolutivos y centrados en animación/UX (archivos modificados: `src/app/app.css`, `src/app/app.html`, `src/app/app.ts`, `src/app/shared/directives/reveal-on-scroll.directive.ts`, `src/styles.css`).

### Testing
- Ejecuté `npm run build` y la compilación terminó satisfactoriamente; se mostraron advertencias de presupuesto CSS (informativas) y el build output fue generado correctamente. 
- Levanté la app con `npm run start -- --host 0.0.0.0 --port 4200` y verifiqué visualmente la página en el servidor de desarrollo, lo que arrancó correctamente. 
- Automatizado: capturé una captura de la home con Playwright (`http://localhost:4200`) para validar el resultado visual y la captura se generó con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f186f9f08328bda1bf642a305511)