### PR TITLE
Add subtle premium glass, heading highlights, and floating cards

### DIFF
--- a/src/app/features/home/home-page/home-page.css
+++ b/src/app/features/home/home-page/home-page.css
@@ -170,6 +170,7 @@
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
+
 .experience-step:hover{
   transform: translateY(-6px);
   box-shadow: 0 18px 34px rgba(41, 22, 73, 0.14);
@@ -325,6 +326,7 @@
   display: flex;
   flex-direction: column;
 }
+
 
 .service-card:hover{
   transform: translateY(-6px);

--- a/src/app/features/home/home-page/home-page.html
+++ b/src/app/features/home/home-page/home-page.html
@@ -81,7 +81,7 @@
   <div class="container">
     <div class="section-heading" appRevealOnScroll>
       <p class="section-tag">Experiencia CBM</p>
-      <h2>Un camino de recuperación que también se siente</h2>
+      <h2 class="heading-highlight">Un camino de recuperación que también se siente</h2>
       <p class="section-description">
         No solo tratamos el dolor: te guiamos paso a paso para que recuperes confianza,
         seguridad y ganas de volver a moverte.
@@ -89,7 +89,7 @@
     </div>
 
     <div class="experience-track">
-      <article class="experience-step reveal-delay-1" appRevealOnScroll>
+      <article class="experience-step reveal-delay-1 glass-panel floating-card" appRevealOnScroll>
         <span class="experience-step-number">01</span>
         <h3>Te escuchamos de verdad</h3>
         <p>
@@ -98,7 +98,7 @@
         </p>
       </article>
 
-      <article class="experience-step reveal-delay-2" appRevealOnScroll>
+      <article class="experience-step reveal-delay-2 glass-panel floating-card" appRevealOnScroll>
         <span class="experience-step-number">02</span>
         <h3>Diseñamos tu plan personal</h3>
         <p>
@@ -107,7 +107,7 @@
         </p>
       </article>
 
-      <article class="experience-step reveal-delay-3" appRevealOnScroll>
+      <article class="experience-step reveal-delay-3 glass-panel floating-card" appRevealOnScroll>
         <span class="experience-step-number">03</span>
         <h3>Acompañamiento cercano</h3>
         <p>
@@ -125,7 +125,7 @@
 
     <div class="section-heading" appRevealOnScroll>
       <p class="section-tag">Nuestros servicios</p>
-      <h2>Tratamientos especializados</h2>
+      <h2 class="heading-highlight">Tratamientos especializados</h2>
       <p class="section-description">
         Soluciones claras para aliviar dolor, mejorar movilidad y prevenir recaídas.
       </p>
@@ -133,7 +133,7 @@
 
     <div class="services-grid">
 
-      <article class="service-card reveal-delay-1" appRevealOnScroll>
+      <article class="service-card reveal-delay-1 glass-panel floating-card" appRevealOnScroll>
         <p class="service-label">Tratamiento</p>
 
         <div class="service-icon">👐</div>
@@ -154,7 +154,7 @@
         <a class="service-link" routerLink="/tratamientos/fisioterapia">Ver todo Tratamiento →</a>
       </article>
 
-      <article class="service-card reveal-delay-2" appRevealOnScroll>
+      <article class="service-card reveal-delay-2 glass-panel floating-card" appRevealOnScroll>
         <p class="service-label">Técnicas</p>
 
         <div class="service-icon">⚡</div>
@@ -176,7 +176,7 @@
         <a class="service-link" routerLink="/tratamientos/tecnicas">Ver todo Técnicas →</a>
       </article>
 
-      <article class="service-card reveal-delay-3" appRevealOnScroll>
+      <article class="service-card reveal-delay-3 glass-panel floating-card" appRevealOnScroll>
         <p class="service-label">Movimiento</p>
 
         <div class="service-icon">🧘</div>
@@ -235,7 +235,7 @@
 <section class="mid-cta section section-flow" appRevealOnScroll>
   <div class="container mid-cta-content">
     <p class="section-tag">Da el primer paso</p>
-    <h2>Reserva tu primera valoración</h2>
+    <h2 class="heading-highlight">Reserva tu primera valoración</h2>
     <p>
       Cuéntanos tu caso y te orientaremos sobre el tratamiento más adecuado para empezar cuanto antes.
     </p>

--- a/src/app/features/testimonials/testimonials.html
+++ b/src/app/features/testimonials/testimonials.html
@@ -4,7 +4,7 @@
       <p class="reviews-highlight">
         ★ {{ averageRating | number:'1.1-1' }} en Google · basado en {{ totalRatings }} reseñas
       </p>
-      <h2>Reseñas reales de Google</h2>
+      <h2 class="heading-highlight">Reseñas reales de Google</h2>
       <p class="section-description">
         Opiniones públicas de pacientes que ya han confiado en CBM Fisioterapia.
       </p>
@@ -16,7 +16,7 @@
     </p>
 
     <div class="testimonials-grid" *ngIf="!loading">
-      <article class="testimonial-card" *ngFor="let review of testimonials">
+      <article class="testimonial-card floating-card glass-panel" *ngFor="let review of testimonials">
         <div class="testimonial-header">
           <img
             *ngIf="review.photoUri"
@@ -38,7 +38,7 @@
       </article>
     </div>
 
-    <div class="reviews-cta">
+    <div class="reviews-cta glass-panel">
       <div class="reviews-cta-info">
         <span class="reviews-stars">{{ getStars(averageRating) }}</span>
         <span class="reviews-score">

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,6 +16,11 @@
   --card-border: 1px solid rgba(241, 216, 230, 0.86);
   --card-bg: rgba(255, 255, 255, 0.8);
   --card-shadow: 0 12px 28px rgba(31, 27, 45, 0.08);
+  --premium-glass-bg: linear-gradient(145deg, rgba(255, 255, 255, 0.82) 0%, rgba(255, 248, 252, 0.68) 100%);
+  --premium-glass-border: 1px solid rgba(241, 216, 230, 0.86);
+  --premium-glass-shadow: 0 14px 32px rgba(31, 27, 45, 0.1);
+  --premium-floating-shadow: 0 16px 34px rgba(31, 27, 45, 0.1);
+  --premium-floating-shadow-hover: 0 22px 44px rgba(31, 27, 45, 0.14);
 }
 
 *{
@@ -66,6 +71,34 @@ img{
   font-size:17px;
   color:var(--color-muted);
   line-height:1.72;
+}
+
+.heading-highlight{
+  position: relative;
+  display: inline;
+  background-image: linear-gradient(120deg, rgba(255, 79, 163, 0.2) 0%, rgba(123, 77, 255, 0.16) 100%);
+  background-repeat: no-repeat;
+  background-size: 100% 0.42em;
+  background-position: 0 88%;
+  padding-bottom: 0.05em;
+}
+
+.glass-panel{
+  border: var(--premium-glass-border);
+  background: var(--premium-glass-bg);
+  box-shadow: var(--premium-glass-shadow);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+}
+
+.floating-card{
+  box-shadow: var(--premium-floating-shadow);
+  transition: transform 0.34s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.34s cubic-bezier(0.22, 1, 0.36, 1), border-color 0.3s ease, color 0.24s ease, background-color 0.24s ease;
+}
+
+.floating-card:hover{
+  transform: translateY(-4px);
+  box-shadow: var(--premium-floating-shadow-hover);
 }
 
 .btn-primary{
@@ -132,6 +165,7 @@ img{
 .benefit-item,
 .service-card,
 .testimonial-card,
+.floating-card,
 .hero-trust span,
 .btn-primary,
 .btn-secondary,
@@ -145,13 +179,15 @@ img{
 .benefit-item:hover,
 .service-card:hover,
 .testimonial-card:hover,
+.floating-card:hover,
 .hero-trust span:hover{
   transform: translateY(-5px);
 }
 
 .benefit-item:hover,
 .service-card:hover,
-.testimonial-card:hover{
+.testimonial-card:hover,
+.floating-card:hover{
   box-shadow: 0 20px 38px rgba(31, 27, 45, 0.12);
 }
 
@@ -186,6 +222,7 @@ img{
   .benefit-item:hover,
   .service-card:hover,
   .testimonial-card:hover,
+  .floating-card:hover,
   .hero-trust span:hover,
   .service-link:hover,
   .btn-secondary:hover,
@@ -201,6 +238,7 @@ img{
   .benefit-item,
   .service-card,
   .testimonial-card,
+  .floating-card,
   .hero-trust span,
   .btn-primary,
   .btn-secondary,
@@ -217,6 +255,7 @@ img{
   .benefit-item:hover,
   .service-card:hover,
   .testimonial-card:hover,
+  .floating-card:hover,
   .hero-trust span:hover,
   .service-link:hover,
   .btn-secondary:hover,
@@ -232,6 +271,12 @@ img{
     transform: none;
     filter: none;
     transition: none;
+  }
+}
+
+@supports not ((-webkit-backdrop-filter: blur(2px)) or (backdrop-filter: blur(2px))){
+  .glass-panel{
+    background: rgba(255, 255, 255, 0.9);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Elevar con sutileza la percepción premium del sitio sin rehacer la home ni cambiar identidad visual, añadiendo profundidad, jerarquía y acabado de calidad. 

### Description
- Añadí utilidades visuales reutilizables en `src/styles.css`: `glass-panel` (frosted/translúcido con `backdrop-filter` y fallback), `heading-highlight` (subrayado/halo editorial sutil) y `floating-card` (sombras y elevación suave con transiciones). 
- Apliqué esas clases de forma selectiva en `src/app/features/home/home-page/home-page.html` (pasos de experiencia, cards de servicios, título del mid-CTA) y en `src/app/features/testimonials/testimonials.html` (títulos, cada tarjeta de reseña y el CTA de reseñas) para no sobreusar el efecto. 
- Conservé la paleta y el fondo animado existentes (no se tocaron las variables de color ni `app.css` que implementa el fondo) y añadí una regla `@supports` para ofrecer un fallback cuando `backdrop-filter` no esté disponible. 
- Mantengo accesibilidad y rendimiento: respeté `prefers-reduced-motion`, añadí un fallback para `backdrop-filter` y limité el uso de blur/elevación solo a bloques estratégicos.

### Testing
- Ejecuté `npm run build` y la compilación finalizó correctamente después de ajustar tamaño de archivos CSS (build: ✅). 
- Levanté el servidor con `npm run start -- --host 0.0.0.0 --port 4200` y verifiqué visualmente los cambios (dev server: ✅). 
- Capturé una captura de la página para revisión visual (artifacts: `artifacts/cbm-home-premium.png`) (captura: ✅). 
- Intenté una comprobación responsive automatizada con Playwright; ese paso falló por un crash del navegador en el entorno de ejecución (no por el código) (Playwright: ⚠️).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f4a2218c8328a642678d22c74128)