### PR TITLE
UX: actualizar CTAs a “Solicitar cita”, microcopy y mejora del botón principal

### DIFF
--- a/src/app/core/floating-booking-button/floating-booking-button.css
+++ b/src/app/core/floating-booking-button/floating-booking-button.css
@@ -7,6 +7,7 @@
   display:inline-flex;
   align-items:center;
   justify-content:center;
+  gap:8px;
 
   min-width:170px;
   padding:14px 22px;

--- a/src/app/core/floating-booking-button/floating-booking-button.html
+++ b/src/app/core/floating-booking-button/floating-booking-button.html
@@ -1,3 +1,4 @@
 <a class="floating-booking-button" href="#reserva">
- Pedir cita
+  <span aria-hidden="true">💬</span>
+  <span>Solicitar cita</span>
 </a>

--- a/src/app/core/footer/footer.html
+++ b/src/app/core/footer/footer.html
@@ -32,7 +32,7 @@
     <div class="footer-column">
       <h4>Enlaces</h4>
       <ul>
-        <li><a href="#reserva">Pedir cita</a></li>
+        <li><a href="#reserva">Solicitar cita</a></li>
         <li><a href="https://www.google.com/search?q=CBM+Fisioterapia+Terrassa" target="_blank" rel="noopener noreferrer">Reseñas</a></li>
         <li><a href="https://www.instagram.com/cbm.fisioterapia/" target="_blank" rel="noopener noreferrer">Instagram</a></li>
         <li><a href="https://www.google.com/maps/search/?api=1&query=Calle+Arquimedes+227+Terrassa" target="_blank" rel="noopener noreferrer">Cómo llegar</a></li>

--- a/src/app/core/header/header.html
+++ b/src/app/core/header/header.html
@@ -15,14 +15,15 @@
         </div>
       </div>
 
-      <a routerLink="/" fragment="reserva">Pedir cita</a>
+      <a routerLink="/" fragment="reserva">Solicitar cita</a>
       <a routerLink="/" fragment="faq">FAQ</a>
       <a routerLink="/" fragment="contacto">Contáctanos</a>
       <a routerLink="/blog">Blog</a>
     </nav>
 
-    <a class="btn-primary header-cta" routerLink="/" fragment="reserva">
-      Pedir cita
+    <a class="btn-primary btn-booking header-cta" routerLink="/" fragment="reserva">
+      <span class="btn-icon" aria-hidden="true">💬</span>
+      <span>Solicitar cita</span>
     </a>
 
     <button
@@ -41,7 +42,7 @@
       <a routerLink="/" fragment="experiencia" (click)="closeMobileMenu()">Experiencia</a>
       <a routerLink="/" fragment="servicios" (click)="closeMobileMenu()">Tratamientos</a>
       <a routerLink="/tratamientos/fisioterapia" (click)="closeMobileMenu()">Ver todo</a>
-      <a routerLink="/" fragment="reserva" (click)="closeMobileMenu()">Pedir cita</a>
+      <a routerLink="/" fragment="reserva" (click)="closeMobileMenu()">Solicitar cita</a>
       <a routerLink="/" fragment="faq" (click)="closeMobileMenu()">FAQ</a>
       <a routerLink="/" fragment="contacto" (click)="closeMobileMenu()">Contáctanos</a>
       <a routerLink="/blog" (click)="closeMobileMenu()">Blog</a>

--- a/src/app/features/blog/blog-page.html
+++ b/src/app/features/blog/blog-page.html
@@ -36,7 +36,10 @@
         ¿Te ocurre algo parecido?
         En CBM Fisioterapia podemos ayudarte a evaluarlo en consulta.
       </p>
-      <a class="btn-primary" routerLink="/" fragment="reserva">Pedir cita</a>
+      <a class="btn-primary btn-booking" routerLink="/" fragment="reserva">
+        <span class="btn-icon" aria-hidden="true">💬</span>
+        <span>Solicitar cita</span>
+      </a>
     </article>
   </div>
 </section>
@@ -59,7 +62,7 @@
         ¿Te ocurre algo parecido?
         En CBM Fisioterapia podemos ayudarte a evaluarlo en consulta.
       </p>
-      <a class="btn-secondary" routerLink="/" fragment="reserva">Reservar valoración</a>
+      <a class="btn-secondary" routerLink="/" fragment="reserva">Solicitar cita</a>
     </article>
   </div>
 </section>

--- a/src/app/features/booking-form/booking-form.html
+++ b/src/app/features/booking-form/booking-form.html
@@ -3,7 +3,7 @@
     <div class="booking-wrapper">
 
       <div class="section-heading" appRevealOnScroll>
-        <p class="section-tag">Reserva tu cita</p>
+        <p class="section-tag">Solicitar cita</p>
         <h2>Cuéntanos qué necesitas</h2>
         <p class="section-description">
           Déjanos tus datos y te llevamos directamente a WhatsApp con el mensaje preparado.
@@ -80,12 +80,13 @@
         </div>
 
         <div class="form-actions">
-          <button class="btn-primary" type="submit">
-            📅 Pedir cita
+          <button class="btn-primary btn-booking" type="submit">
+            <span class="btn-icon" aria-hidden="true">💬</span>
+            <span>Solicitar cita</span>
           </button>
         </div>
 
-        <p class="form-note">Te responderemos rápido por WhatsApp para confirmar tu cita.</p>
+        <p class="form-note">Te contactaremos por WhatsApp para confirmar disponibilidad y horario.</p>
       </form>
 
     </div>

--- a/src/app/features/booking-form/booking-form.ts
+++ b/src/app/features/booking-form/booking-form.ts
@@ -28,7 +28,7 @@ export class BookingFormComponent {
     const promoCodeLine = this.promoCode.trim()
       ? `\n    Código promocional: ${this.promoCode}`
       : '';
-    const rawMessage = `Hola, quiero pedir cita.\n\n    Nombre: ${this.formData.name}${surnameLine}\n    Descripción: ${this.formData.message}${promoCodeLine}`;
+    const rawMessage = `Hola, quiero solicitar cita.\n\n    Nombre: ${this.formData.name}${surnameLine}\n    Descripción: ${this.formData.message}${promoCodeLine}`;
     const encodedMessage = encodeURIComponent(rawMessage);
     const url = `https://wa.me/${phoneNumber}?text=${encodedMessage}`;
 

--- a/src/app/features/home/home-page/home-page.css
+++ b/src/app/features/home/home-page/home-page.css
@@ -94,22 +94,12 @@
 
 .hero-trust{
   margin-top: 18px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.hero-trust span{
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 12px;
-  border-radius: 999px;
-  border: 1px solid rgba(241, 216, 230, 0.9);
-  background: rgba(255, 255, 255, 0.72);
-  color: #4f4961;
-  font-size: 13px;
+  margin-bottom: 0;
+  color: #6c6480;
+  font-size: 12px;
   font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.5;
 }
 
 .hero-image-card{
@@ -553,10 +543,6 @@
 
   .hero-trust{
     margin-top: 14px;
-    gap: 8px;
-  }
-
-  .hero-trust span{
     font-size: 12px;
   }
 

--- a/src/app/features/home/home-page/home-page.html
+++ b/src/app/features/home/home-page/home-page.html
@@ -27,15 +27,14 @@
       </div>
 
       <div class="hero-buttons">
-        <a class="btn-primary" href="#reserva">Pedir cita</a>
+        <a class="btn-primary btn-booking" href="#reserva">
+          <span class="btn-icon" aria-hidden="true">💬</span>
+          <span>Solicitar cita</span>
+        </a>
         <a class="btn-secondary" href="#servicios">Ver tratamientos</a>
       </div>
 
-      <div class="hero-trust" aria-label="Señales de confianza">
-        <span><i aria-hidden="true">★</i> 5.0 en Google</span>
-        <span><i aria-hidden="true">📍</i> Centro en Terrassa</span>
-        <span><i aria-hidden="true">♥</i> Atención personalizada</span>
-      </div>
+      <p class="hero-trust" aria-label="Señales de confianza">★★★★★ 5.0 en Google · Centro en Terrassa · Atención personalizada</p>
     </div>
 
     <div class="hero-image reveal-delay-2" appRevealOnScroll>
@@ -235,12 +234,15 @@
 <section class="mid-cta section section-flow" appRevealOnScroll>
   <div class="container mid-cta-content">
     <p class="section-tag">Da el primer paso</p>
-    <h2 class="heading-highlight">Reserva tu primera valoración</h2>
+    <h2 class="heading-highlight">Solicita tu primera valoración</h2>
     <p>
       Cuéntanos tu caso y te orientaremos sobre el tratamiento más adecuado para empezar cuanto antes.
     </p>
-    <a class="btn-primary" href="#reserva">Reservar ahora</a>
-    <p class="mid-cta-note">Respuesta rápida por WhatsApp.</p>
+    <a class="btn-primary btn-booking" href="#reserva">
+      <span class="btn-icon" aria-hidden="true">💬</span>
+      <span>Solicitar cita</span>
+    </a>
+    <p class="mid-cta-note">Te contactaremos por WhatsApp para confirmar disponibilidad y horario.</p>
   </div>
 </section>
 

--- a/src/app/features/seo-pages/seo-page.component.html
+++ b/src/app/features/seo-pages/seo-page.component.html
@@ -42,7 +42,10 @@
         Si buscas un centro de fisioterapia en Terrassa con atención personalizada,
         podemos orientarte desde la primera visita.
       </p>
-      <a class="btn-primary" routerLink="/" fragment="reserva">Pedir cita en CBM Fisioterapia</a>
+      <a class="btn-primary btn-booking" routerLink="/" fragment="reserva">
+        <span class="btn-icon" aria-hidden="true">💬</span>
+        <span>Solicitar cita en CBM Fisioterapia</span>
+      </a>
     </section>
   </div>
 </section>

--- a/src/styles.css
+++ b/src/styles.css
@@ -105,6 +105,7 @@ img{
   display:inline-flex;
   align-items:center;
   justify-content:center;
+  gap: 8px;
   background:var(--gradient-brand);
   color:white;
   padding:14px 28px;
@@ -113,14 +114,23 @@ img{
   text-decoration:none;
   font-weight:600;
   cursor:pointer;
-  box-shadow: 0 10px 22px rgba(123, 77, 255, 0.24);
-  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.28s ease, box-shadow 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+  box-shadow: 0 12px 24px rgba(123, 77, 255, 0.24);
+  transition: transform 0.32s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.26s ease, box-shadow 0.32s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .btn-primary:hover{
-  transform: translateY(-3px);
+  transform: translateY(-2px);
   opacity:0.96;
-  box-shadow: 0 16px 30px rgba(123, 77, 255, 0.3);
+  box-shadow: 0 16px 30px rgba(123, 77, 255, 0.32);
+}
+
+.btn-booking .btn-icon{
+  font-size: 16px;
+  line-height: 1;
+}
+
+.btn-booking span:last-child{
+  line-height: 1;
 }
 
 .btn-secondary{
@@ -166,7 +176,6 @@ img{
 .service-card,
 .testimonial-card,
 .floating-card,
-.hero-trust span,
 .btn-primary,
 .btn-secondary,
 .btn-google-reviews,
@@ -179,8 +188,7 @@ img{
 .benefit-item:hover,
 .service-card:hover,
 .testimonial-card:hover,
-.floating-card:hover,
-.hero-trust span:hover{
+.floating-card:hover{
   transform: translateY(-5px);
 }
 
@@ -203,17 +211,6 @@ img{
   transform: translateY(-2px) scale(1.03);
 }
 
-.hero-trust span i{
-  font-style: normal;
-  color: #7b4dff;
-  opacity: 0.9;
-}
-
-.hero-trust span:hover{
-  border-color: rgba(255, 79, 163, 0.35);
-  box-shadow: 0 10px 20px rgba(31, 27, 45, 0.08);
-}
-
 .service-link:hover{
   transform: translateX(2px);
 }
@@ -223,7 +220,6 @@ img{
   .service-card:hover,
   .testimonial-card:hover,
   .floating-card:hover,
-  .hero-trust span:hover,
   .service-link:hover,
   .btn-secondary:hover,
   .social-btn:hover,
@@ -239,7 +235,6 @@ img{
   .service-card,
   .testimonial-card,
   .floating-card,
-  .hero-trust span,
   .btn-primary,
   .btn-secondary,
   .btn-google-reviews,
@@ -256,7 +251,6 @@ img{
   .service-card:hover,
   .testimonial-card:hover,
   .floating-card:hover,
-  .hero-trust span:hover,
   .service-link:hover,
   .btn-secondary:hover,
   .social-btn:hover,


### PR DESCRIPTION
### Motivation
- Alinear el lenguaje de las llamadas a la acción con el flujo real (datos → WhatsApp → confirmación manual) para reducir fricción y expectativas falsas.
- Aclarar el proceso de confirmación por WhatsApp y mantener tono cercano y profesional sin rehacer la estructura visual actual.
- Mejorar sutilmente la apariencia y el feedback del botón principal para aumentar confianza y CTR manteniendo el gradiente y la identidad visual.

### Description
- Reemplacé textos de CTAs relacionados con cita por “Solicitar cita” y cambié “Reserva tu primera valoración” por “Solicita tu primera valoración” en navegación, hero, mid-cta, formulario, blog, SEO, footer y botón flotante (varios archivos modificados: header, footer, home, booking form, blog, seo-page, floating button).
- Añadí la microcopy aclaratoria bajo los CTAs relevantes: `Te contactaremos por WhatsApp para confirmar disponibilidad y horario.` en el formulario y en el mid-cta del hero.
- Introduje la clase `btn-booking` y añadí un icono de mensaje (💬) dentro de los CTAs de cita, además de ajustes CSS para hover suave (`transform: translateY(-2px)`), ligera elevación y sombra refinada manteniendo el gradiente existente.
- Simplifiqué la línea de confianza del hero a una frase discreta y responsive: `★★★★★ 5.0 en Google · Centro en Terrassa · Atención personalizada` y actualicé el mensaje predefinido de WhatsApp a `Hola, quiero solicitar cita.`

### Testing
- Ejecuté `npm run build` y la compilación de Angular se completó correctamente (con warnings de tamaño de CSS), resultado: éxito.
- Levanté el servidor de desarrollo (`ng serve`) y tomé una captura con Playwright para ver integración visual del hero/CTA, resultado: captura generada sin romper layout.
- Verifiqué mediante búsquedas (`rg`) que las cadenas antiguas fueron reemplazadas por las nuevas y que no quedaron referencias relevantes, resultado: éxito.
- No se añadieron tests unitarios; cambios son de copy y estilos y fueron validados mediante build y revisión visual.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55f60d40883288a9b299a54f51a08)