### PR TITLE
Rediseña sección de solicitud de cita en home con CTA principal a Calendly

### DIFF
--- a/src/app/core/floating-booking-button/floating-booking-button.css
+++ b/src/app/core/floating-booking-button/floating-booking-button.css
@@ -57,3 +57,11 @@
     transition: none;
   }
 }
+
+@media (max-width: 768px) {
+  body.booking-mobile-focus .floating-booking-button {
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(10px) scale(0.92);
+  }
+}

--- a/src/app/core/floating-whatsapp-button/floating-whatsapp-button.css
+++ b/src/app/core/floating-whatsapp-button/floating-whatsapp-button.css
@@ -73,3 +73,11 @@
     display: none;
   }
 }
+
+@media (max-width: 768px){
+  body.booking-mobile-focus .floating-whatsapp-button{
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(10px) scale(0.92);
+  }
+}

--- a/src/app/features/booking-form/booking-form.css
+++ b/src/app/features/booking-form/booking-form.css
@@ -61,6 +61,7 @@
   padding: 18px;
   box-shadow: 0 16px 34px rgba(31, 27, 45, 0.08);
   backdrop-filter: blur(6px);
+  overflow: hidden;
 }
 
 .booking-context {
@@ -168,8 +169,8 @@
   }
 
   .booking-shell {
-    border-radius: 18px;
-    padding: 12px;
+    border-radius: 16px;
+    padding: 10px;
   }
 
   .booking-context,
@@ -184,7 +185,8 @@
   }
 
   .calendly-frame {
-    height: 640px;
+    height: 700px;
+    min-height: 700px;
   }
 
   .booking-support {
@@ -196,5 +198,35 @@
 
   .support-text {
     min-width: 100%;
+  }
+}
+
+
+@media (max-width: 560px) {
+  .booking-form .container {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+
+  .booking-shell {
+    padding: 10px;
+    border-radius: 14px;
+  }
+
+  .calendly-frame-wrap {
+    border-radius: 12px;
+  }
+
+  .calendly-frame {
+    height: 710px;
+    min-height: 710px;
+  }
+
+  .booking-note {
+    margin-top: 12px;
+  }
+
+  .booking-note-duration {
+    margin-top: 6px;
   }
 }

--- a/src/app/features/booking-form/booking-form.css
+++ b/src/app/features/booking-form/booking-form.css
@@ -63,6 +63,23 @@
   backdrop-filter: blur(6px);
 }
 
+.booking-context {
+  margin: 2px 4px 8px;
+  color: #4d465d;
+  font-size: 14px;
+  line-height: 1.45;
+  text-align: center;
+}
+
+.calendly-heading {
+  margin: 0 4px 12px;
+  color: #302b3f;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.35;
+  text-align: center;
+}
+
 .calendly-frame-wrap {
   border: 1px solid rgba(235, 217, 229, 0.95);
   border-radius: 20px;
@@ -76,6 +93,18 @@
   height: 720px;
   border: 0;
   display: block;
+}
+
+.booking-note {
+  margin: 10px 2px 0;
+  color: #746d85;
+  font-size: 12px;
+  line-height: 1.4;
+  text-align: center;
+}
+
+.booking-note-duration {
+  margin-top: 4px;
 }
 
 .booking-support {
@@ -141,6 +170,13 @@
   .booking-shell {
     border-radius: 18px;
     padding: 12px;
+  }
+
+  .booking-context,
+  .calendly-heading {
+    text-align: left;
+    margin-left: 2px;
+    margin-right: 2px;
   }
 
   .calendly-frame-wrap {

--- a/src/app/features/booking-form/booking-form.css
+++ b/src/app/features/booking-form/booking-form.css
@@ -1,106 +1,135 @@
 .booking-form {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.32) 0%, rgba(255, 247, 251, 0.62) 100%);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.26) 0%, rgba(255, 247, 251, 0.56) 100%);
   padding: 96px 0;
 }
 
 .booking-wrapper {
-  max-width: 1100px;
+  max-width: 1120px;
   margin: 0 auto;
 }
 
-.booking-card {
-  display: grid;
-  grid-template-columns: 1.25fr 0.9fr;
-  gap: 32px;
-  align-items: center;
-  background: rgba(255, 255, 255, 0.82);
-  border: 1px solid rgba(241, 216, 230, 0.9);
-  border-radius: var(--radius-card);
-  padding: 36px;
-  box-shadow: 0 14px 32px rgba(31, 27, 45, 0.08);
-  backdrop-filter: blur(5px);
+.booking-header {
+  max-width: 760px;
+  margin: 0 auto 28px;
+  text-align: center;
 }
 
-.booking-copy h2 {
+.booking-header h2 {
   margin: 10px 0 12px;
 }
 
 .section-description {
-  max-width: 62ch;
+  margin: 0 auto;
+  max-width: 60ch;
 }
 
-.booking-benefits {
-  margin: 20px 0 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 10px;
-}
-
-.booking-benefits li {
-  position: relative;
-  margin: 0;
-  padding-left: 24px;
-  color: #4a445b;
-  font-weight: 500;
-  line-height: 1.55;
-}
-
-.booking-benefits li::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0.5em;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, #ff7abf 0%, #ff4fa3 65%, #dd2a82 100%);
-  box-shadow: 0 0 0 4px rgba(255, 79, 163, 0.14);
-}
-
-.booking-actions {
-  background: rgba(255, 255, 255, 0.94);
-  border: 1px solid rgba(237, 220, 232, 0.95);
-  border-radius: 18px;
-  padding: 24px;
-  box-shadow: 0 8px 24px rgba(48, 31, 60, 0.08);
+.trust-points {
+  margin: 18px auto 0;
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.btn-calendly,
-.btn-whatsapp {
-  width: 100%;
+  flex-wrap: wrap;
   justify-content: center;
-  text-align: center;
+  gap: 8px;
 }
 
-.btn-calendly {
-  min-height: 52px;
-}
-
-.btn-whatsapp {
-  min-height: 50px;
-}
-
-.booking-note {
-  margin: 4px 0 0;
-  color: #746d85;
+.trust-points span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(236, 216, 229, 0.92);
+  background: rgba(255, 255, 255, 0.8);
+  color: #534c63;
   font-size: 13px;
+  font-weight: 500;
+  line-height: 1.3;
+}
+
+.trust-points span::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ff4fa3;
+  box-shadow: 0 0 0 3px rgba(255, 79, 163, 0.14);
+}
+
+.booking-shell {
+  background: rgba(255, 255, 255, 0.84);
+  border: 1px solid rgba(241, 216, 230, 0.95);
+  border-radius: var(--radius-card);
+  padding: 18px;
+  box-shadow: 0 16px 34px rgba(31, 27, 45, 0.08);
+  backdrop-filter: blur(6px);
+}
+
+.calendly-frame-wrap {
+  border: 1px solid rgba(235, 217, 229, 0.95);
+  border-radius: 20px;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.55);
+}
+
+.calendly-frame {
+  width: 100%;
+  height: 720px;
+  border: 0;
+  display: block;
+}
+
+.booking-support {
+  margin-top: 14px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(238, 225, 235, 0.95);
+  background: rgba(255, 255, 255, 0.9);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px 16px;
+}
+
+.support-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #302b3f;
+}
+
+.support-text {
+  margin: 0;
+  color: #625a74;
+  font-size: 14px;
   line-height: 1.45;
-  text-align: center;
+  flex: 1;
+  min-width: 240px;
+}
+
+.support-link {
+  color: #5f4f74;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(95, 79, 116, 0.4);
+  padding-bottom: 2px;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.support-link:hover,
+.support-link:focus-visible {
+  color: #3f3254;
+  border-color: rgba(63, 50, 84, 0.7);
 }
 
 @media (max-width: 1024px) {
-  .booking-card {
-    grid-template-columns: 1fr;
-    gap: 24px;
-    padding: 30px;
+  .booking-header {
+    margin-bottom: 24px;
   }
 
-  .section-description {
-    max-width: 100%;
+  .calendly-frame {
+    height: 680px;
   }
 }
 
@@ -109,23 +138,27 @@
     padding: 66px 0 76px;
   }
 
-  .booking-card {
-    padding: 22px 16px;
+  .booking-shell {
     border-radius: 18px;
-    gap: 20px;
+    padding: 12px;
   }
 
-  .booking-actions {
-    padding: 18px;
+  .calendly-frame-wrap {
     border-radius: 14px;
   }
 
-  .booking-benefits {
-    gap: 8px;
+  .calendly-frame {
+    height: 640px;
   }
 
-  .booking-benefits li {
-    font-size: 14px;
-    padding-left: 22px;
+  .booking-support {
+    margin-top: 10px;
+    padding: 12px;
+    border-radius: 12px;
+    align-items: flex-start;
+  }
+
+  .support-text {
+    min-width: 100%;
   }
 }

--- a/src/app/features/booking-form/booking-form.css
+++ b/src/app/features/booking-form/booking-form.css
@@ -1,153 +1,131 @@
-.booking-form{
+.booking-form {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.32) 0%, rgba(255, 247, 251, 0.62) 100%);
   padding: 96px 0;
 }
 
-.booking-wrapper{
-  max-width:1100px;
-  margin:0 auto;
+.booking-wrapper {
+  max-width: 1100px;
+  margin: 0 auto;
 }
 
-.form-card{
-  max-width:860px;
-  margin:30px auto 0;
-  background: rgba(255, 255, 255, 0.78);
-  border:1px solid rgba(241, 216, 230, 0.9);
-  border-radius:var(--radius-card);
-  padding:34px;
-  box-shadow:0 12px 28px rgba(31, 27, 45, 0.08);
+.booking-card {
+  display: grid;
+  grid-template-columns: 1.25fr 0.9fr;
+  gap: 32px;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(241, 216, 230, 0.9);
+  border-radius: var(--radius-card);
+  padding: 36px;
+  box-shadow: 0 14px 32px rgba(31, 27, 45, 0.08);
   backdrop-filter: blur(5px);
 }
 
-.form-grid{
-  display:grid;
-  grid-template-columns:1fr 1fr;
-  gap:16px;
+.booking-copy h2 {
+  margin: 10px 0 12px;
 }
 
-.form-group{
-  display:flex;
-  flex-direction:column;
-  margin-bottom:16px;
+.section-description {
+  max-width: 62ch;
 }
 
-.form-group label{
-  margin-bottom:7px;
-  font-weight:600;
-  color:#332d43;
-  font-size: 14px;
-}
-
-.form-group input,
-.form-group textarea{
-  border:1px solid rgba(231, 205, 221, 0.9);
-  border-radius:12px;
-  padding:14px 16px;
-  font-size:16px;
-  font-family:inherit;
-  outline:none;
-  background: rgba(255, 255, 255, 0.95);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.form-group input:focus,
-.form-group textarea:focus{
-  border-color:#ff4fa3;
-  box-shadow: 0 0 0 3px rgba(255, 79, 163, 0.13);
-}
-
-.form-actions{
-  margin-top: 8px;
-  display: flex;
-  justify-content: flex-start;
-}
-
-.form-actions .btn-primary{
-  min-width: 240px;
-}
-
-.form-note{
-  margin: 12px 0 0;
-  color: #6e6780;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-
-.promo-toggle{
-  margin: 0 0 12px;
+.booking-benefits {
+  margin: 20px 0 0;
   padding: 0;
-  border: 0;
-  background: transparent;
-  color: #7d6e8e;
-  font: inherit;
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 1.4;
-  text-align: left;
-  cursor: pointer;
-  align-self: flex-start;
-  transition: color 0.2s ease, opacity 0.2s ease;
+  list-style: none;
+  display: grid;
+  gap: 10px;
 }
 
-.promo-toggle:hover,
-.promo-toggle:focus-visible{
-  color: #5f4f74;
-  opacity: 0.92;
+.booking-benefits li {
+  position: relative;
+  margin: 0;
+  padding-left: 24px;
+  color: #4a445b;
+  font-weight: 500;
+  line-height: 1.55;
 }
 
-.promo-toggle:focus-visible{
-  outline: 2px solid rgba(255, 79, 163, 0.3);
-  outline-offset: 4px;
-  border-radius: 8px;
+.booking-benefits li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.5em;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #ff7abf 0%, #ff4fa3 65%, #dd2a82 100%);
+  box-shadow: 0 0 0 4px rgba(255, 79, 163, 0.14);
 }
 
-.promo-group{
-  margin-top: -2px;
+.booking-actions {
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(237, 220, 232, 0.95);
+  border-radius: 18px;
+  padding: 24px;
+  box-shadow: 0 8px 24px rgba(48, 31, 60, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.promo-help{
-  margin: 8px 2px 0;
-  color: #7a728a;
-  font-size: 12px;
+.btn-calendly,
+.btn-whatsapp {
+  width: 100%;
+  justify-content: center;
+  text-align: center;
+}
+
+.btn-calendly {
+  min-height: 52px;
+}
+
+.btn-whatsapp {
+  min-height: 50px;
+}
+
+.booking-note {
+  margin: 4px 0 0;
+  color: #746d85;
+  font-size: 13px;
   line-height: 1.45;
+  text-align: center;
 }
 
+@media (max-width: 1024px) {
+  .booking-card {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding: 30px;
+  }
 
-@media (max-width: 1024px){
-  .form-actions .btn-primary{
-    min-width: 0;
-    width: 100%;
+  .section-description {
+    max-width: 100%;
   }
 }
 
-@media (max-width: 768px){
-  .booking-form{
+@media (max-width: 768px) {
+  .booking-form {
     padding: 66px 0 76px;
   }
 
-  .booking-wrapper{
-    max-width: 100%;
-  }
-
-  .form-card{
-    max-width: 100%;
-    margin: 24px auto 0;
+  .booking-card {
     padding: 22px 16px;
+    border-radius: 18px;
+    gap: 20px;
   }
 
-  .form-grid{
-    grid-template-columns: 1fr;
-    gap: 0;
+  .booking-actions {
+    padding: 18px;
+    border-radius: 14px;
   }
 
-
-  .promo-toggle{
-    min-height: 40px;
+  .booking-benefits {
+    gap: 8px;
   }
 
-  .form-actions .btn-primary{
-    width: 100%;
-    min-width: 0;
+  .booking-benefits li {
+    font-size: 14px;
+    padding-left: 22px;
   }
 }

--- a/src/app/features/booking-form/booking-form.html
+++ b/src/app/features/booking-form/booking-form.html
@@ -1,94 +1,46 @@
 <section id="reserva" class="booking-form section">
   <div class="container">
     <div class="booking-wrapper">
-
-      <div class="section-heading" appRevealOnScroll>
-        <p class="section-tag">Solicitar cita</p>
-        <h2>Cuéntanos qué necesitas</h2>
-        <p class="section-description">
-          Déjanos tus datos y te llevamos directamente a WhatsApp con el mensaje preparado.
-        </p>
-      </div>
-
-      <form
-        class="form-card reveal-delay-1"
-        appRevealOnScroll
-        (ngSubmit)="sendWhatsApp()"
-        #bookingForm="ngForm"
-      >
-        <div class="form-grid">
-          <div class="form-group">
-            <label for="name">Nombre</label>
-            <input
-              id="name"
-              name="name"
-              type="text"
-              [(ngModel)]="formData.name"
-              placeholder="Tu nombre"
-              required
-            />
-          </div>
-
-          <div class="form-group">
-            <label for="surname">Apellido</label>
-            <input
-              id="surname"
-              name="surname"
-              type="text"
-              [(ngModel)]="formData.surname"
-              placeholder="Opcional"
-            />
-          </div>
-        </div>
-
-        <div class="form-group">
-          <label for="message">Breve descripción</label>
-          <textarea
-            id="message"
-            name="message"
-            rows="5"
-            [(ngModel)]="formData.message"
-            placeholder="Cuéntanos brevemente qué te ocurre o qué quieres mejorar"
-            required
-          ></textarea>
-        </div>
-
-        <button
-          type="button"
-          class="promo-toggle"
-          (click)="togglePromoCode()"
-          [attr.aria-expanded]="showPromoCode"
-          aria-controls="promoCodeGroup"
-        >
-          ¿Tienes un código promocional?
-        </button>
-
-        <div class="form-group promo-group" id="promoCodeGroup" *ngIf="showPromoCode">
-          <label for="promoCode">Código promocional</label>
-          <input
-            id="promoCode"
-            name="promoCode"
-            type="text"
-            [(ngModel)]="promoCode"
-            placeholder="Ej. BIENVENIDA10"
-            autocomplete="off"
-          />
-          <p class="promo-help">
-            Si tienes un código promocional, escríbelo aquí y lo confirmaremos por WhatsApp al revisar tu
-            solicitud.
+      <article class="booking-card" appRevealOnScroll>
+        <div class="booking-copy">
+          <p class="section-tag">Reserva tu sesión</p>
+          <h2>Empieza tu recuperación con una cita guiada</h2>
+          <p class="section-description">
+            Elige día y hora en menos de 1 minuto. Te acompañamos desde el primer paso con un proceso claro,
+            cómodo y profesional.
           </p>
+
+          <ul class="booking-benefits" aria-label="Ventajas de reservar online">
+            <li>Confirmación inmediata con Calendly.</li>
+            <li>Horario flexible para adaptarnos a ti.</li>
+            <li>Atención por WhatsApp si prefieres ayuda directa.</li>
+          </ul>
         </div>
 
-        <div class="form-actions">
-          <button class="btn-primary btn-booking" type="submit">
-            <span class="btn-icon" aria-hidden="true">💬</span>
-            <span>Solicitar cita</span>
-          </button>
+        <div class="booking-actions" appRevealOnScroll>
+          <a
+            class="btn-primary btn-calendly"
+            [href]="calendlyUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Reservar cita en Calendly en una nueva pestaña"
+          >
+            Reservar cita ahora
+          </a>
+
+          <a
+            class="btn-secondary btn-whatsapp"
+            [href]="whatsAppUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Escribir por WhatsApp como alternativa de reserva"
+          >
+            Prefiero reservar por WhatsApp
+          </a>
+
+          <p class="booking-note">Calendly se abrirá en una nueva pestaña.</p>
         </div>
-
-        <p class="form-note">Te contactaremos por WhatsApp para confirmar disponibilidad y horario.</p>
-      </form>
-
+      </article>
     </div>
   </div>
 </section>

--- a/src/app/features/booking-form/booking-form.html
+++ b/src/app/features/booking-form/booking-form.html
@@ -1,45 +1,46 @@
 <section id="reserva" class="booking-form section">
   <div class="container">
     <div class="booking-wrapper">
-      <article class="booking-card" appRevealOnScroll>
-        <div class="booking-copy">
-          <p class="section-tag">Reserva tu sesión</p>
-          <h2>Empieza tu recuperación con una cita guiada</h2>
-          <p class="section-description">
-            Elige día y hora en menos de 1 minuto. Te acompañamos desde el primer paso con un proceso claro,
-            cómodo y profesional.
-          </p>
+      <header class="booking-header" appRevealOnScroll>
+        <p class="section-tag">Reserva online</p>
+        <h2>Tu sesión de fisioterapia, aquí mismo</h2>
+        <p class="section-description">
+          Elige el día y la hora que mejor te encajen en una agenda clara y sin salir de la web.
+        </p>
 
-          <ul class="booking-benefits" aria-label="Ventajas de reservar online">
-            <li>Confirmación inmediata con Calendly.</li>
-            <li>Horario flexible para adaptarnos a ti.</li>
-            <li>Atención por WhatsApp si prefieres ayuda directa.</li>
-          </ul>
+        <div class="trust-points" aria-label="Puntos de confianza de la reserva">
+          <span>Confirmación inmediata</span>
+          <span>Proceso guiado y sencillo</span>
+          <span>Soporte humano si lo necesitas</span>
+        </div>
+      </header>
+
+      <article class="booking-shell" appRevealOnScroll>
+        <div class="calendly-frame-wrap">
+          <iframe
+            class="calendly-frame"
+            [src]="calendlyEmbedUrl"
+            title="Reserva tu sesión de fisioterapia"
+            loading="lazy"
+            referrerpolicy="no-referrer-when-downgrade"
+          ></iframe>
         </div>
 
-        <div class="booking-actions" appRevealOnScroll>
+        <aside class="booking-support" aria-label="Ayuda para la reserva">
+          <p class="support-title">¿Prefieres hablar antes de reservar?</p>
+          <p class="support-text">
+            Si tienes dudas sobre el tratamiento o el tipo de sesión, te atendemos por WhatsApp.
+          </p>
           <a
-            class="btn-primary btn-calendly"
-            [href]="calendlyUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Reservar cita en Calendly en una nueva pestaña"
-          >
-            Reservar cita ahora
-          </a>
-
-          <a
-            class="btn-secondary btn-whatsapp"
+            class="support-link"
             [href]="whatsAppUrl"
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="Escribir por WhatsApp como alternativa de reserva"
+            aria-label="Hablar por WhatsApp"
           >
-            Prefiero reservar por WhatsApp
+            Hablar por WhatsApp
           </a>
-
-          <p class="booking-note">Calendly se abrirá en una nueva pestaña.</p>
-        </div>
+        </aside>
       </article>
     </div>
   </div>

--- a/src/app/features/booking-form/booking-form.html
+++ b/src/app/features/booking-form/booking-form.html
@@ -3,19 +3,22 @@
     <div class="booking-wrapper">
       <header class="booking-header" appRevealOnScroll>
         <p class="section-tag">Reserva online</p>
-        <h2>Tu sesión de fisioterapia, aquí mismo</h2>
+        <h2>Reserva tu sesión en pocos segundos</h2>
         <p class="section-description">
-          Elige el día y la hora que mejor te encajen en una agenda clara y sin salir de la web.
+          Elige el día y la hora que mejor te encajen en una agenda clara y sin complicaciones
         </p>
 
         <div class="trust-points" aria-label="Puntos de confianza de la reserva">
-          <span>Confirmación inmediata</span>
-          <span>Proceso guiado y sencillo</span>
-          <span>Soporte humano si lo necesitas</span>
+          <span>Sin esperas</span>
+          <span>Horarios claros</span>
+          <span>Reserva rápida</span>
         </div>
       </header>
 
       <article class="booking-shell" appRevealOnScroll>
+        <p class="booking-context">Fisioterapia personalizada y pilates terapéutico en grupos reducidos</p>
+        <p class="calendly-heading">Elige el día y la hora que mejor te encajen</p>
+
         <div class="calendly-frame-wrap">
           <iframe
             class="calendly-frame"
@@ -26,11 +29,12 @@
           ></iframe>
         </div>
 
+        <p class="booking-note">El pago se realiza en el centro el día de la sesión</p>
+        <p class="booking-note booking-note-duration">Sesión de 60 minutos</p>
+
         <aside class="booking-support" aria-label="Ayuda para la reserva">
-          <p class="support-title">¿Prefieres hablar antes de reservar?</p>
-          <p class="support-text">
-            Si tienes dudas sobre el tratamiento o el tipo de sesión, te atendemos por WhatsApp.
-          </p>
+          <p class="support-title">¿Tienes dudas? Te ayudamos por WhatsApp</p>
+          <p class="support-text">Respuesta rápida durante horario laboral</p>
           <a
             class="support-link"
             [href]="whatsAppUrl"

--- a/src/app/features/booking-form/booking-form.ts
+++ b/src/app/features/booking-form/booking-form.ts
@@ -1,4 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { AfterViewInit, Component, ElementRef, OnDestroy, inject } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { RevealOnScrollDirective } from '../../shared/directives/reveal-on-scroll.directive';
 
@@ -9,12 +10,44 @@ import { RevealOnScrollDirective } from '../../shared/directives/reveal-on-scrol
   templateUrl: './booking-form.html',
   styleUrls: ['./booking-form.css']
 })
-export class BookingFormComponent {
+export class BookingFormComponent implements AfterViewInit, OnDestroy {
   private readonly sanitizer = inject(DomSanitizer);
+  private readonly host = inject(ElementRef<HTMLElement>);
+  private readonly document = inject(DOCUMENT);
+
+  private observer?: IntersectionObserver;
 
   readonly calendlyEmbedUrl: SafeResourceUrl = this.sanitizer.bypassSecurityTrustResourceUrl(
     'https://calendly.com/d/cxy5-km7-cmn/sesion-fisioterapia?hide_event_type_details=1&hide_gdpr_banner=1&background_color=ffffff&text_color=302b3f&primary_color=ff4fa3'
   );
 
   readonly whatsAppUrl = 'https://wa.me/34662561672';
+
+  ngAfterViewInit(): void {
+    if (!window.matchMedia('(max-width: 768px)').matches) {
+      return;
+    }
+
+    const section = this.host.nativeElement.querySelector('#reserva');
+    if (!section) {
+      return;
+    }
+
+    this.observer = new IntersectionObserver(
+      ([entry]) => {
+        this.document.body.classList.toggle('booking-mobile-focus', entry.isIntersecting);
+      },
+      {
+        root: null,
+        threshold: 0.35
+      }
+    );
+
+    this.observer.observe(section);
+  }
+
+  ngOnDestroy(): void {
+    this.observer?.disconnect();
+    this.document.body.classList.remove('booking-mobile-focus');
+  }
 }

--- a/src/app/features/booking-form/booking-form.ts
+++ b/src/app/features/booking-form/booking-form.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { RevealOnScrollDirective } from '../../shared/directives/reveal-on-scroll.directive';
 
 @Component({
@@ -9,6 +10,11 @@ import { RevealOnScrollDirective } from '../../shared/directives/reveal-on-scrol
   styleUrls: ['./booking-form.css']
 })
 export class BookingFormComponent {
-  readonly calendlyUrl = 'https://calendly.com/d/cxy5-km7-cmn/sesion-fisioterapia';
+  private readonly sanitizer = inject(DomSanitizer);
+
+  readonly calendlyEmbedUrl: SafeResourceUrl = this.sanitizer.bypassSecurityTrustResourceUrl(
+    'https://calendly.com/d/cxy5-km7-cmn/sesion-fisioterapia?hide_event_type_details=1&hide_gdpr_banner=1&background_color=ffffff&text_color=302b3f&primary_color=ff4fa3'
+  );
+
   readonly whatsAppUrl = 'https://wa.me/34662561672';
 }

--- a/src/app/features/booking-form/booking-form.ts
+++ b/src/app/features/booking-form/booking-form.ts
@@ -1,83 +1,14 @@
-import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { Component } from '@angular/core';
 import { RevealOnScrollDirective } from '../../shared/directives/reveal-on-scroll.directive';
-import { LanguageService } from '../../core/language/language.service';
 
 @Component({
   selector: 'app-booking-form',
   standalone: true,
-  imports: [CommonModule, FormsModule, RevealOnScrollDirective],
+  imports: [RevealOnScrollDirective],
   templateUrl: './booking-form.html',
   styleUrls: ['./booking-form.css']
 })
 export class BookingFormComponent {
-  private readonly languageService = inject(LanguageService);
-
-  showPromoCode = false;
-  promoCode = '';
-
-  formData = {
-    name: '',
-    surname: '',
-    message: ''
-  };
-
-  sendWhatsApp(): void {
-    const phoneNumber = '34662561672';
-    const selectedLanguage = this.languageService.selectedLanguage;
-
-    const textByLanguage: Record<
-      'es' | 'en' | 'ca',
-      {
-        greeting: string;
-        nameLabel: string;
-        surnameLabel: string;
-        descriptionLabel: string;
-        promoLabel: string;
-      }
-    > = {
-      es: {
-        greeting: 'Hola, quiero solicitar cita.',
-        nameLabel: 'Nombre',
-        surnameLabel: 'Apellido',
-        descriptionLabel: 'Descripción',
-        promoLabel: 'Código promocional'
-      },
-      en: {
-        greeting: 'Hi, I would like to book an appointment.',
-        nameLabel: 'Name',
-        surnameLabel: 'Surname',
-        descriptionLabel: 'Description',
-        promoLabel: 'Promo code'
-      },
-      ca: {
-        greeting: 'Hola, vull sol·licitar cita.',
-        nameLabel: 'Nom',
-        surnameLabel: 'Cognom',
-        descriptionLabel: 'Descripció',
-        promoLabel: 'Codi promocional'
-      }
-    };
-
-    const t = textByLanguage[selectedLanguage];
-
-    const surnameLine = this.formData.surname.trim()
-      ? `\n    ${t.surnameLabel}: ${this.formData.surname}`
-      : '';
-
-    const promoCodeLine = this.promoCode.trim()
-      ? `\n    ${t.promoLabel}: ${this.promoCode}`
-      : '';
-
-    const rawMessage = `${t.greeting}\n\n    ${t.nameLabel}: ${this.formData.name}${surnameLine}\n    ${t.descriptionLabel}: ${this.formData.message}${promoCodeLine}`;
-    const encodedMessage = encodeURIComponent(rawMessage);
-    const url = `https://wa.me/${phoneNumber}?text=${encodedMessage}`;
-
-    window.open(url, '_blank');
-  }
-
-  togglePromoCode(): void {
-    this.showPromoCode = !this.showPromoCode;
-  }
+  readonly calendlyUrl = 'https://calendly.com/d/cxy5-km7-cmn/sesion-fisioterapia';
+  readonly whatsAppUrl = 'https://wa.me/34662561672';
 }


### PR DESCRIPTION
### Motivation
- Reducir fricción en la reserva pasando del mini-formulario a un flujo directo hacia la agenda real (Calendly) para mejorar conversión.
- Modernizar la sección manteniendo la línea visual del sitio (estética premium, bordes redondeados, sombras suaves y diseño ligero).
- Ofrecer una alternativa humana y familiar mediante WhatsApp sin competir con la CTA principal.

### Description
- Se reemplaza el formulario por una card informativa con dos bloques (contenido + acciones) y copy orientado a conversión; el HTML nuevo está en `src/app/features/booking-form/booking-form.html`.
- Estilos rediseñados y responsivos en `src/app/features/booking-form/booking-form.css` con grid de dos columnas que colapsa a una en móvil, sombras suaves, radios y microcopy claro.
- Simplificación del componente en `src/app/features/booking-form/booking-form.ts`, eliminando dependencias de formulario y lógica de generación de mensajes, y dejando solo las URLs de Calendly y WhatsApp.
- Comportamiento de UX: CTA principal `Reservar cita ahora` abre Calendly en nueva pestaña, CTA secundaria `Prefiero reservar por WhatsApp` abre WhatsApp como alternativa.

### Testing
- Ejecutado `npm run build` y la compilación de la aplicación fue exitosa (`ng build` completo sin errores).
- La build mostró advertencias de budget CSS preexistentes en otros archivos no modificados, que no impiden la entrega y se mantuvieron sin cambios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb9a5460b88328817fd4581f440f57)