### PR TITLE
Persistir canje de bono regalo y prevenir reuso

### DIFF
--- a/src/app/canjear/canjear-regalo.component.ts
+++ b/src/app/canjear/canjear-regalo.component.ts
@@ -165,17 +165,42 @@ export class CanjearRegaloComponent implements OnDestroy {
     this.cdr.detectChanges();
 
     // Esperar que termine la animación CSS de explosión (500ms) antes de cambiar estado
-    setTimeout(() => {
+    setTimeout(async () => {
       this.estado = 'animacion';
-      // Canjear en background sin bloquear la animación
-      if (this.bono) {
-        void this.bonosRegaloService.canjearBono(this.bono.codigo)
-          .then(actualizado => { this.bono = actualizado; this.cdr.detectChanges(); })
-          .catch(err => console.error('Error canjeando bono:', err));
-      }
-      // Pasar al vale tras la animación de apertura
-      setTimeout(() => { this.estado = 'vale'; this.cdr.detectChanges(); }, 2600);
       this.cdr.detectChanges();
+
+      const waitForOpeningAnimation = new Promise<void>((resolve) => setTimeout(resolve, 2600));
+
+      try {
+        if (!this.bono) {
+          await waitForOpeningAnimation;
+          this.estado = 'no_encontrado';
+          return;
+        }
+
+        const actualizado = await this.bonosRegaloService.canjearBono(this.bono.codigo);
+        await waitForOpeningAnimation;
+        this.bono = actualizado;
+        this.estado = 'vale';
+      } catch (err) {
+        console.error('Error canjeando bono:', err);
+        await waitForOpeningAnimation;
+        const errorCode = (err as { code?: string } | null)?.code;
+
+        if (errorCode === 'BONO_YA_CANJEADO') {
+          this.estado = 'ya_canjeado';
+          return;
+        }
+
+        if (errorCode === 'BONO_NO_DISPONIBLE') {
+          this.estado = 'pendiente_pago';
+          return;
+        }
+
+        this.estado = 'no_encontrado';
+      } finally {
+        this.cdr.detectChanges();
+      }
     }, 500);
   }
 

--- a/src/app/core/services/bonos-regalo.service.ts
+++ b/src/app/core/services/bonos-regalo.service.ts
@@ -82,18 +82,42 @@ export class BonosRegaloService {
   }
 
   async canjearBono(codigo: string): Promise<BonoRegalo> {
+    const normalizedCode = codigo.toUpperCase().trim();
     const { data, error } = await supabase
       .from('bonos_regalo')
       .update({ estado: 'canjeado', fecha_canje: new Date().toISOString() })
-      .eq('codigo', codigo.toUpperCase().trim())
+      .eq('codigo', normalizedCode)
+      .in('estado', ['pagado', 'enviado'])
       .select('*')
-      .single();
+      .maybeSingle();
 
     if (error) {
       throw error;
     }
 
-    return data as BonoRegalo;
+    if (data) {
+      return data as BonoRegalo;
+    }
+
+    const { data: existing, error: existingError } = await supabase
+      .from('bonos_regalo')
+      .select('estado')
+      .eq('codigo', normalizedCode)
+      .maybeSingle();
+
+    if (existingError) {
+      throw existingError;
+    }
+
+    if (!existing) {
+      throw Object.assign(new Error('Bono no encontrado'), { code: 'BONO_NO_ENCONTRADO' });
+    }
+
+    if (existing.estado === 'canjeado') {
+      throw Object.assign(new Error('Este bono ya ha sido canjeado'), { code: 'BONO_YA_CANJEADO' });
+    }
+
+    throw Object.assign(new Error('Este bono no está disponible para canjear'), { code: 'BONO_NO_DISPONIBLE' });
   }
 
   async deleteBono(id: string): Promise<void> {


### PR DESCRIPTION
### Motivation
- El canje mostraba éxito visual sin esperar a que el `update` en Supabase persistiera, permitiendo uso múltiple del mismo bono.
- Es necesario asegurar persistencia inmediata del estado `canjeado` y bloquear reusos/condiciones de carrera con cambios mínimos.

### Description
- Se actualizó `src/app/core/services/bonos-regalo.service.ts` para que `canjearBono` haga un `UPDATE` condicionado por `codigo` y `estado IN ('pagado','enviado')`, persista `fecha_canje` y devuelva el registro actualizado; si no hay fila afectada, consulta el estado y lanza errores con códigos `BONO_NO_ENCONTRADO`, `BONO_YA_CANJEADO` o `BONO_NO_DISPONIBLE`.
- Se cambió `src/app/canjear/canjear-regalo.component.ts` para esperar el resultado del servicio antes de mostrar éxito; el componente ahora mapea los códigos de error para bloquear la UI y mostrar estados `ya_canjeado`, `pendiente_pago` o `no_encontrado` en lugar de un éxito visual no persistido.
- El `UPDATE` en el servicio implementa la operación segura/atómica por cliente usando `.eq('codigo', ...)` + `.in('estado', ['pagado','enviado'])` y `.maybeSingle()` para detectar si no se actualizó la fila y reaccionar apropiadamente.
- Cambios limitados a sólo los dos archivos del flujo de canje sin refactor global ni cambios en políticas de RLS/SQL del esquema.

### Testing
- Se corrió `npm run build` y la compilación completó correctamente sin errores (warnings de tamaño de bundle únicamente). 
- Se verificó el diff y se confirmó el commit con mensaje `Fix gift voucher redemption persistence and reuse checks`.
- No se añadieron tests automáticos nuevos; la validación principal fue la compilación exitosa del proyecto.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d64ede7ae883289da9d8c91e672d3d)