### PR TITLE
Mejora de jerarquía en tarifas y preselección de tratamiento para reservar cita

### DIFF
--- a/src/app/features/booking-form/booking-form.css
+++ b/src/app/features/booking-form/booking-form.css
@@ -180,6 +180,19 @@
   margin: 0 0 20px;
 }
 
+.selected-treatment-inline{
+  margin: 0 0 16px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(123, 77, 255, 0.2);
+  background: rgba(123, 77, 255, 0.06);
+  color: #4d4860;
+  font-size: 13px;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
 /* ── Treatment cards (paso 1) ──────────────────────────── */
 .treatment-groups{
   display: flex;

--- a/src/app/features/booking-form/booking-form.html
+++ b/src/app/features/booking-form/booking-form.html
@@ -145,6 +145,10 @@
           <!-- Paso 2: Tus datos -->
           <div *ngIf="currentStep === 2" [class]="'stepper-pane ' + stepAnimClass">
             <h3 class="step-title">¿Cómo te llamas?</h3>
+            <p *ngIf="preselectedFromPricing" class="selected-treatment-inline">
+              Has elegido: <strong>{{ selectedTreatmentOption?.nombre }}</strong>
+              <span>{{ selectedTreatmentOption?.precio }}</span>
+            </p>
 
             <div class="form-grid">
               <div class="form-group">

--- a/src/app/features/booking-form/booking-form.html
+++ b/src/app/features/booking-form/booking-form.html
@@ -144,11 +144,11 @@
 
           <!-- Paso 2: Tus datos -->
           <div *ngIf="currentStep === 2" [class]="'stepper-pane ' + stepAnimClass">
-            <h3 class="step-title">¿Cómo te llamas?</h3>
             <p *ngIf="preselectedFromPricing" class="selected-treatment-inline">
-              Has elegido: <strong>{{ selectedTreatmentOption?.nombre }}</strong>
+              Tratamiento seleccionado <strong>{{ selectedTreatmentOption?.nombre }}</strong>
               <span>{{ selectedTreatmentOption?.precio }}</span>
             </p>
+            <h3 class="step-title">¿Cómo te llamas?</h3>
 
             <div class="form-grid">
               <div class="form-group">

--- a/src/app/features/booking-form/booking-form.ts
+++ b/src/app/features/booking-form/booking-form.ts
@@ -1,7 +1,7 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { ChangeDetectorRef, Component, inject, OnInit, PLATFORM_ID } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { RouterLink } from '@angular/router';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { RevealOnScrollDirective } from '../../shared/directives/reveal-on-scroll.directive';
 import { LanguageService } from '../../core/language/language.service';
 import { Tarifa, TarifaCategoria, TarifasService } from '../../core/services/tarifas.service';
@@ -31,7 +31,8 @@ export class BookingFormComponent implements OnInit {
   constructor(
     private readonly tarifasService: TarifasService,
     private readonly languageService: LanguageService,
-    private readonly cdr: ChangeDetectorRef
+    private readonly cdr: ChangeDetectorRef,
+    private readonly route: ActivatedRoute
   ) {}
 
   currentStep = 1;
@@ -43,6 +44,7 @@ export class BookingFormComponent implements OnInit {
   whatsAppFeedback = false;
   loadingTarifas = true;
   errorTarifas = false;
+  preselectedFromPricing = false;
   enviando = false;
   errorEnvio = false;
   solicitudEnviada = false;
@@ -67,6 +69,7 @@ export class BookingFormComponent implements OnInit {
     try {
       const tarifas = await this.tarifasService.getTarifas();
       this.treatmentOptions = tarifas.map((tarifa) => this.toTreatmentOption(tarifa));
+      this.applyPreselectionFromQuery();
     } catch {
       this.treatmentOptions = [];
       this.errorTarifas = true;
@@ -79,6 +82,23 @@ export class BookingFormComponent implements OnInit {
   private initAvailability(): void {
     this.availabilityType = 'green';
     this.availabilityText = 'Solo falta un paso para confirmar tu cita';
+  }
+
+  private applyPreselectionFromQuery(): void {
+    const treatmentFromQuery = this.route.snapshot.queryParamMap.get('tratamiento');
+    const stepFromQuery = this.route.snapshot.queryParamMap.get('paso');
+    if (!treatmentFromQuery) return;
+
+    const matched = this.treatmentOptions.find((option) => option.value === treatmentFromQuery);
+    if (!matched) return;
+
+    this.formData.treatment = matched.value;
+    this.preselectedFromPricing = true;
+
+    if (stepFromQuery === '2') {
+      this.currentStep = 2;
+      this.stepAnimClass = 'step-enter-forward';
+    }
   }
 
   private readonly categoryLabels: Record<TarifaCategoria, string> = {

--- a/src/app/sections/pricing/pricing.component.css
+++ b/src/app/sections/pricing/pricing.component.css
@@ -75,18 +75,47 @@
   gap: 14px;
 }
 
+.pricing-item-button{
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+}
+
+.pricing-item-button:focus-visible{
+  outline: 2px solid rgba(255, 79, 163, 0.35);
+  outline-offset: 4px;
+  border-radius: 10px;
+}
+
 .concept{
-  color: #4e485f;
-  font-size: 15px;
-  line-height: 1.45;
+  color: #332d43;
+  font-size: 16px;
+  line-height: 1.35;
+  font-weight: 700;
 }
 
 .price{
   color: #1f1b2d;
-  font-size: clamp(1.35rem, 2.2vw, 1.7rem);
+  font-size: clamp(1.45rem, 2.4vw, 1.85rem);
   font-weight: 800;
   letter-spacing: -0.01em;
   white-space: nowrap;
+}
+
+.item-action{
+  margin-top: 5px;
+  display: inline-flex;
+  font-size: 12px;
+  color: #7b4dff;
+  font-weight: 600;
+}
+
+.pricing-item-button--selected .item-action{
+  color: #ff4fa3;
 }
 
 .microtext{
@@ -95,6 +124,25 @@
   color: #7a748d;
   font-size: 13px;
   line-height: 1.45;
+}
+
+.microtext--expanded{
+  margin-top: 8px;
+}
+
+.details-toggle{
+  margin-top: 4px;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: #6c4ec5;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.details-toggle:hover{
+  color: #ff4fa3;
 }
 
 /* ── Mejora 3: urgency badges ──────────────────────────── */
@@ -305,6 +353,10 @@
   .pricing-row{
     flex-wrap: wrap;
     row-gap: 4px;
+  }
+
+  .concept{
+    font-size: 15px;
   }
 
   .price{

--- a/src/app/sections/pricing/pricing.component.css
+++ b/src/app/sections/pricing/pricing.component.css
@@ -131,18 +131,35 @@
 }
 
 .details-toggle{
-  margin-top: 4px;
+  margin-top: 10px;
   border: 0;
   background: transparent;
   padding: 0;
-  color: #6c4ec5;
-  font-size: 12px;
-  font-weight: 600;
+  color: #7b7690;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
   cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: rgba(123, 118, 144, 0.38);
+  text-underline-offset: 3px;
 }
 
 .details-toggle:hover{
-  color: #ff4fa3;
+  color: #6c4ec5;
+  text-decoration-color: rgba(108, 78, 197, 0.45);
+}
+
+.details-content{
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease, opacity 0.22s ease;
+}
+
+.details-content.is-open{
+  max-height: 220px;
+  opacity: 1;
 }
 
 /* ── Mejora 3: urgency badges ──────────────────────────── */

--- a/src/app/sections/pricing/pricing.component.css
+++ b/src/app/sections/pricing/pricing.component.css
@@ -78,17 +78,36 @@
 .pricing-item-button{
   width: 100%;
   padding: 0;
-  border: 0;
-  background: transparent;
   text-align: left;
-  cursor: pointer;
   font: inherit;
 }
 
-.pricing-item-button:focus-visible{
+.pricing-list-item{
+  border-radius: 14px;
+  padding: 10px 10px 12px;
+  margin: -10px -10px 0;
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.22s ease, transform 0.22s ease;
+}
+
+.pricing-list-item:focus-visible{
   outline: 2px solid rgba(255, 79, 163, 0.35);
   outline-offset: 4px;
-  border-radius: 10px;
+  border-radius: 14px;
+}
+
+.pricing-list-item:hover{
+  background: rgba(255, 255, 255, 0.74);
+  box-shadow: 0 8px 20px rgba(123, 77, 255, 0.12);
+}
+
+.pricing-list-item:active{
+  transform: translateY(1px);
+  box-shadow: 0 4px 12px rgba(123, 77, 255, 0.1);
+}
+
+.pricing-list-item--selected{
+  background: rgba(255, 79, 163, 0.06);
 }
 
 .concept{
@@ -114,7 +133,7 @@
   font-weight: 600;
 }
 
-.pricing-item-button--selected .item-action{
+.pricing-list-item--selected .item-action{
   color: #ff4fa3;
 }
 

--- a/src/app/sections/pricing/pricing.component.css
+++ b/src/app/sections/pricing/pricing.component.css
@@ -119,29 +119,40 @@
 }
 
 .microtext{
-  margin-top: 5px;
+  margin-top: 6px;
   display: block;
   color: #7a748d;
   font-size: 13px;
-  line-height: 1.45;
+  line-height: 1.52;
+}
+
+.microtext--preview{
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.microtext--hidden{
+  display: none;
 }
 
 .microtext--expanded{
-  margin-top: 8px;
+  margin-top: 0;
 }
 
 .details-toggle{
-  margin-top: 10px;
+  margin-top: 8px;
   border: 0;
   background: transparent;
   padding: 0;
-  color: #7b7690;
+  color: #756f88;
   font-size: 11px;
-  font-weight: 500;
+  font-weight: 550;
   letter-spacing: 0.01em;
   cursor: pointer;
   text-decoration: underline;
-  text-decoration-color: rgba(123, 118, 144, 0.38);
+  text-decoration-color: rgba(117, 111, 136, 0.32);
   text-underline-offset: 3px;
 }
 
@@ -154,12 +165,18 @@
   max-height: 0;
   opacity: 0;
   overflow: hidden;
-  transition: max-height 0.3s ease, opacity 0.22s ease;
+  padding-left: 0;
+  margin-top: 0;
+  border-left: 1px solid transparent;
+  transition: max-height 0.3s ease, opacity 0.22s ease, margin-top 0.25s ease, padding-left 0.25s ease, border-color 0.25s ease;
 }
 
 .details-content.is-open{
-  max-height: 220px;
+  max-height: 260px;
   opacity: 1;
+  margin-top: 8px;
+  padding-left: 10px;
+  border-left-color: rgba(123, 77, 255, 0.2);
 }
 
 /* ── Mejora 3: urgency badges ──────────────────────────── */

--- a/src/app/sections/pricing/pricing.component.html
+++ b/src/app/sections/pricing/pricing.component.html
@@ -24,19 +24,22 @@
         <h3>{{ card.title }}</h3>
 
         <ul class="pricing-list" role="list">
-          <li *ngFor="let item of card.items">
-            <button
-              type="button"
-              class="pricing-item-button"
-              [class.pricing-item-button--selected]="selectedItemId === item.id"
-              (click)="selectAndBook(item)"
-            >
+          <li
+            *ngFor="let item of card.items"
+            class="pricing-list-item"
+            [class.pricing-list-item--selected]="selectedItemId === item.id"
+            role="button"
+            tabindex="0"
+            (click)="selectAndBook(item)"
+            (keydown)="onCardKeydown($event, item)"
+          >
+            <div class="pricing-item-button">
               <div class="pricing-row">
                 <span class="concept">{{ item.concept }}</span>
                 <strong class="price">{{ item.price }}</strong>
               </div>
-              <span class="item-action">Reservar esta opción →</span>
-            </button>
+              <span class="item-action">Reservar esta sesión →</span>
+            </div>
             <p *ngIf="item.fechaFinPromo" class="fecha-fin-indicator">
               ✨ Disponible hasta el {{ formatFechaFin(item.fechaFinPromo) }}
             </p>
@@ -51,7 +54,7 @@
               *ngIf="item.hasLongDescription"
               type="button"
               class="details-toggle"
-              (click)="toggleDetails(item.id)"
+              (click)="toggleDetails(item.id, $event)"
               [attr.aria-expanded]="isItemExpanded(item.id)"
             >
               {{ isItemExpanded(item.id) ? 'Ocultar información' : 'Más información' }}

--- a/src/app/sections/pricing/pricing.component.html
+++ b/src/app/sections/pricing/pricing.component.html
@@ -25,14 +25,34 @@
 
         <ul class="pricing-list" role="list">
           <li *ngFor="let item of card.items">
-            <div class="pricing-row">
-              <span class="concept">{{ item.concept }}</span>
-              <strong class="price">{{ item.price }}</strong>
-            </div>
+            <button
+              type="button"
+              class="pricing-item-button"
+              [class.pricing-item-button--selected]="selectedItemId === item.id"
+              (click)="selectAndBook(item)"
+            >
+              <div class="pricing-row">
+                <span class="concept">{{ item.concept }}</span>
+                <strong class="price">{{ item.price }}</strong>
+              </div>
+              <span class="item-action">Elegir y solicitar cita →</span>
+            </button>
             <p *ngIf="item.fechaFinPromo" class="fecha-fin-indicator">
               ✨ Disponible hasta el {{ formatFechaFin(item.fechaFinPromo) }}
             </p>
-            <small *ngIf="item.microtext" class="microtext">{{ item.microtext }}</small>
+            <small *ngIf="item.microtextShort" class="microtext">{{ item.microtextShort }}</small>
+            <button
+              *ngIf="item.hasLongDescription"
+              type="button"
+              class="details-toggle"
+              (click)="toggleDetails(item.id)"
+              [attr.aria-expanded]="isItemExpanded(item.id)"
+            >
+              {{ isItemExpanded(item.id) ? 'Ocultar detalles' : 'Ver detalles' }}
+            </button>
+            <small *ngIf="item.hasLongDescription && isItemExpanded(item.id)" class="microtext microtext--expanded">
+              {{ item.microtext }}
+            </small>
             <span *ngIf="item.urgencyType === 'warning'" class="urgency-badge urgency-badge--warning">
               ⏰ Quedan {{ item.urgencyDays }} días
             </span>
@@ -65,7 +85,7 @@
     <div class="pricing-cta" appRevealOnScroll>
       <a class="btn-primary btn-booking" routerLink="/solicitar-cita">
         <span class="btn-icon" aria-hidden="true">💬</span>
-        <span>Solicitar cita</span>
+        <span>¿Prefieres decidir después? Solicitar cita</span>
       </a>
     </div>
 

--- a/src/app/sections/pricing/pricing.component.html
+++ b/src/app/sections/pricing/pricing.component.html
@@ -35,7 +35,7 @@
                 <span class="concept">{{ item.concept }}</span>
                 <strong class="price">{{ item.price }}</strong>
               </div>
-              <span class="item-action">Elegir y solicitar cita →</span>
+              <span class="item-action">Reservar esta opción →</span>
             </button>
             <p *ngIf="item.fechaFinPromo" class="fecha-fin-indicator">
               ✨ Disponible hasta el {{ formatFechaFin(item.fechaFinPromo) }}
@@ -80,13 +80,6 @@
           Cuéntanos tu situación →
         </button>
       </div>
-    </div>
-
-    <div class="pricing-cta" appRevealOnScroll>
-      <a class="btn-primary btn-booking" routerLink="/solicitar-cita">
-        <span class="btn-icon" aria-hidden="true">💬</span>
-        <span>¿Prefieres decidir después? Solicitar cita</span>
-      </a>
     </div>
 
     </ng-container>

--- a/src/app/sections/pricing/pricing.component.html
+++ b/src/app/sections/pricing/pricing.component.html
@@ -48,11 +48,11 @@
               (click)="toggleDetails(item.id)"
               [attr.aria-expanded]="isItemExpanded(item.id)"
             >
-              {{ isItemExpanded(item.id) ? 'Ocultar detalles' : 'Ver detalles' }}
+              {{ isItemExpanded(item.id) ? 'Ver menos' : 'Ver más' }}
             </button>
-            <small *ngIf="item.hasLongDescription && isItemExpanded(item.id)" class="microtext microtext--expanded">
-              {{ item.microtext }}
-            </small>
+            <div *ngIf="item.hasLongDescription" class="details-content" [class.is-open]="isItemExpanded(item.id)">
+              <small class="microtext microtext--expanded">{{ item.microtextMore }}</small>
+            </div>
             <span *ngIf="item.urgencyType === 'warning'" class="urgency-badge urgency-badge--warning">
               ⏰ Quedan {{ item.urgencyDays }} días
             </span>

--- a/src/app/sections/pricing/pricing.component.html
+++ b/src/app/sections/pricing/pricing.component.html
@@ -40,7 +40,13 @@
             <p *ngIf="item.fechaFinPromo" class="fecha-fin-indicator">
               ✨ Disponible hasta el {{ formatFechaFin(item.fechaFinPromo) }}
             </p>
-            <small *ngIf="item.microtextShort" class="microtext">{{ item.microtextShort }}</small>
+            <small
+              *ngIf="item.microtext"
+              class="microtext microtext--preview"
+              [class.microtext--hidden]="item.hasLongDescription && isItemExpanded(item.id)"
+            >
+              {{ item.microtext }}
+            </small>
             <button
               *ngIf="item.hasLongDescription"
               type="button"
@@ -48,10 +54,10 @@
               (click)="toggleDetails(item.id)"
               [attr.aria-expanded]="isItemExpanded(item.id)"
             >
-              {{ isItemExpanded(item.id) ? 'Ver menos' : 'Ver más' }}
+              {{ isItemExpanded(item.id) ? 'Ocultar información' : 'Más información' }}
             </button>
             <div *ngIf="item.hasLongDescription" class="details-content" [class.is-open]="isItemExpanded(item.id)">
-              <small class="microtext microtext--expanded">{{ item.microtextMore }}</small>
+              <small class="microtext microtext--expanded">{{ item.microtext }}</small>
             </div>
             <span *ngIf="item.urgencyType === 'warning'" class="urgency-badge urgency-badge--warning">
               ⏰ Quedan {{ item.urgencyDays }} días

--- a/src/app/sections/pricing/pricing.component.ts
+++ b/src/app/sections/pricing/pricing.component.ts
@@ -13,6 +13,7 @@ interface PricingItem {
   price: string;
   microtext?: string;
   microtextShort?: string;
+  microtextMore?: string;
   hasLongDescription?: boolean;
   urgencyDays?: number;
   urgencyType?: 'warning' | 'urgent';
@@ -41,7 +42,7 @@ export class PricingComponent implements OnInit {
   domicilioMensaje =
     'Pensado para recuperaciones postparto, post-cirugía o movilidad reducida. Valoramos cada caso con cariño.';
   showDomicilioModal = false;
-  expandedItems: Record<string, boolean> = {};
+  expandedItemId: string | null = null;
   selectedItemId: string | null = null;
   private readonly maxPreviewLength = 120;
 
@@ -71,11 +72,11 @@ export class PricingComponent implements OnInit {
   }
 
   toggleDetails(itemId: string): void {
-    this.expandedItems[itemId] = !this.expandedItems[itemId];
+    this.expandedItemId = this.expandedItemId === itemId ? null : itemId;
   }
 
   isItemExpanded(itemId: string): boolean {
-    return !!this.expandedItems[itemId];
+    return this.expandedItemId === itemId;
   }
 
   selectAndBook(item: PricingItem): void {
@@ -123,16 +124,16 @@ export class PricingComponent implements OnInit {
 
   private toPricingItem(tarifa: Tarifa): PricingItem {
     const description = tarifa.descripcion?.trim() ?? '';
-    const hasLongDescription = description.length > this.maxPreviewLength;
+    const { short, more } = this.getDescriptionParts(description);
+    const hasLongDescription = !!more;
 
     const item: PricingItem = {
       id: tarifa.id,
       concept: tarifa.nombre,
       price: `${tarifa.precio}${tarifa.unidad}`,
       microtext: description || undefined,
-      microtextShort: hasLongDescription
-        ? `${description.slice(0, this.maxPreviewLength).trimEnd()}…`
-        : description || undefined,
+      microtextShort: short || undefined,
+      microtextMore: more || undefined,
       hasLongDescription,
       fechaFinPromo: tarifa.fecha_fin_promo ?? null
     };
@@ -154,5 +155,31 @@ export class PricingComponent implements OnInit {
     }
 
     return item;
+  }
+
+  private getDescriptionParts(text: string): { short: string; more: string } {
+    if (!text) return { short: '', more: '' };
+    if (text.length <= this.maxPreviewLength) return { short: text, more: '' };
+
+    const minCut = Math.floor(this.maxPreviewLength * 0.6);
+    const punctuation = ['. ', ': ', '; ', '· ', ', '];
+    let cut = -1;
+
+    for (const mark of punctuation) {
+      const idx = text.lastIndexOf(mark, this.maxPreviewLength);
+      if (idx >= minCut) {
+        cut = idx + mark.length;
+        break;
+      }
+    }
+
+    if (cut === -1) {
+      const lastSpace = text.lastIndexOf(' ', this.maxPreviewLength);
+      cut = lastSpace > minCut ? lastSpace : this.maxPreviewLength;
+    }
+
+    const short = `${text.slice(0, cut).trim()}…`;
+    const more = text.slice(cut).trim();
+    return { short, more };
   }
 }

--- a/src/app/sections/pricing/pricing.component.ts
+++ b/src/app/sections/pricing/pricing.component.ts
@@ -3,7 +3,7 @@ import { NgFor, NgIf } from '@angular/common';
 import { RevealOnScrollDirective } from '../../shared/directives/reveal-on-scroll.directive';
 import { Tarifa, TarifasService } from '../../core/services/tarifas.service';
 import { CbmLoaderComponent } from '../../shared/components/cbm-loader/cbm-loader.component';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { ConfiguracionService } from '../../core/services/configuracion.service';
 import { DomicilioFormComponent } from '../../shared/components/domicilio-form/domicilio-form.component';
 
@@ -28,7 +28,7 @@ interface PricingCard {
 @Component({
   selector: 'app-pricing',
   standalone: true,
-  imports: [NgFor, NgIf, RevealOnScrollDirective, CbmLoaderComponent, RouterLink, DomicilioFormComponent],
+  imports: [NgFor, NgIf, RevealOnScrollDirective, CbmLoaderComponent, DomicilioFormComponent],
   templateUrl: './pricing.component.html',
   styleUrls: ['./pricing.component.css']
 })

--- a/src/app/sections/pricing/pricing.component.ts
+++ b/src/app/sections/pricing/pricing.component.ts
@@ -3,14 +3,17 @@ import { NgFor, NgIf } from '@angular/common';
 import { RevealOnScrollDirective } from '../../shared/directives/reveal-on-scroll.directive';
 import { Tarifa, TarifasService } from '../../core/services/tarifas.service';
 import { CbmLoaderComponent } from '../../shared/components/cbm-loader/cbm-loader.component';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { ConfiguracionService } from '../../core/services/configuracion.service';
 import { DomicilioFormComponent } from '../../shared/components/domicilio-form/domicilio-form.component';
 
 interface PricingItem {
+  id: string;
   concept: string;
   price: string;
   microtext?: string;
+  microtextShort?: string;
+  hasLongDescription?: boolean;
   urgencyDays?: number;
   urgencyType?: 'warning' | 'urgent';
   fechaFinPromo?: string | null;
@@ -38,10 +41,14 @@ export class PricingComponent implements OnInit {
   domicilioMensaje =
     'Pensado para recuperaciones postparto, post-cirugía o movilidad reducida. Valoramos cada caso con cariño.';
   showDomicilioModal = false;
+  expandedItems: Record<string, boolean> = {};
+  selectedItemId: string | null = null;
+  private readonly maxPreviewLength = 120;
 
   constructor(
     private readonly tarifasService: TarifasService,
-    private readonly configuracionService: ConfiguracionService
+    private readonly configuracionService: ConfiguracionService,
+    private readonly router: Router
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -61,6 +68,24 @@ export class PricingComponent implements OnInit {
     } finally {
       this.loading = false;
     }
+  }
+
+  toggleDetails(itemId: string): void {
+    this.expandedItems[itemId] = !this.expandedItems[itemId];
+  }
+
+  isItemExpanded(itemId: string): boolean {
+    return !!this.expandedItems[itemId];
+  }
+
+  selectAndBook(item: PricingItem): void {
+    this.selectedItemId = item.id;
+    this.router.navigate(['/solicitar-cita'], {
+      queryParams: {
+        tratamiento: item.id,
+        paso: 2
+      }
+    });
   }
 
   formatFechaFin(fecha: string): string {
@@ -97,10 +122,18 @@ export class PricingComponent implements OnInit {
   }
 
   private toPricingItem(tarifa: Tarifa): PricingItem {
+    const description = tarifa.descripcion?.trim() ?? '';
+    const hasLongDescription = description.length > this.maxPreviewLength;
+
     const item: PricingItem = {
+      id: tarifa.id,
       concept: tarifa.nombre,
       price: `${tarifa.precio}${tarifa.unidad}`,
-      microtext: tarifa.descripcion ?? undefined,
+      microtext: description || undefined,
+      microtextShort: hasLongDescription
+        ? `${description.slice(0, this.maxPreviewLength).trimEnd()}…`
+        : description || undefined,
+      hasLongDescription,
       fechaFinPromo: tarifa.fecha_fin_promo ?? null
     };
 

--- a/src/app/sections/pricing/pricing.component.ts
+++ b/src/app/sections/pricing/pricing.component.ts
@@ -69,7 +69,8 @@ export class PricingComponent implements OnInit {
     }
   }
 
-  toggleDetails(itemId: string): void {
+  toggleDetails(itemId: string, event?: Event): void {
+    event?.stopPropagation();
     this.expandedItemId = this.expandedItemId === itemId ? null : itemId;
   }
 
@@ -85,6 +86,15 @@ export class PricingComponent implements OnInit {
         paso: 2
       }
     });
+  }
+
+  onCardKeydown(event: KeyboardEvent, item: PricingItem): void {
+    if (event.key !== 'Enter') {
+      return;
+    }
+
+    event.preventDefault();
+    this.selectAndBook(item);
   }
 
   formatFechaFin(fecha: string): string {

--- a/src/app/sections/pricing/pricing.component.ts
+++ b/src/app/sections/pricing/pricing.component.ts
@@ -12,8 +12,6 @@ interface PricingItem {
   concept: string;
   price: string;
   microtext?: string;
-  microtextShort?: string;
-  microtextMore?: string;
   hasLongDescription?: boolean;
   urgencyDays?: number;
   urgencyType?: 'warning' | 'urgent';
@@ -44,7 +42,7 @@ export class PricingComponent implements OnInit {
   showDomicilioModal = false;
   expandedItemId: string | null = null;
   selectedItemId: string | null = null;
-  private readonly maxPreviewLength = 120;
+  private readonly maxPreviewLength = 140;
 
   constructor(
     private readonly tarifasService: TarifasService,
@@ -124,16 +122,13 @@ export class PricingComponent implements OnInit {
 
   private toPricingItem(tarifa: Tarifa): PricingItem {
     const description = tarifa.descripcion?.trim() ?? '';
-    const { short, more } = this.getDescriptionParts(description);
-    const hasLongDescription = !!more;
+    const hasLongDescription = description.length > this.maxPreviewLength;
 
     const item: PricingItem = {
       id: tarifa.id,
       concept: tarifa.nombre,
       price: `${tarifa.precio}${tarifa.unidad}`,
       microtext: description || undefined,
-      microtextShort: short || undefined,
-      microtextMore: more || undefined,
       hasLongDescription,
       fechaFinPromo: tarifa.fecha_fin_promo ?? null
     };
@@ -155,31 +150,5 @@ export class PricingComponent implements OnInit {
     }
 
     return item;
-  }
-
-  private getDescriptionParts(text: string): { short: string; more: string } {
-    if (!text) return { short: '', more: '' };
-    if (text.length <= this.maxPreviewLength) return { short: text, more: '' };
-
-    const minCut = Math.floor(this.maxPreviewLength * 0.6);
-    const punctuation = ['. ', ': ', '; ', '· ', ', '];
-    let cut = -1;
-
-    for (const mark of punctuation) {
-      const idx = text.lastIndexOf(mark, this.maxPreviewLength);
-      if (idx >= minCut) {
-        cut = idx + mark.length;
-        break;
-      }
-    }
-
-    if (cut === -1) {
-      const lastSpace = text.lastIndexOf(' ', this.maxPreviewLength);
-      cut = lastSpace > minCut ? lastSpace : this.maxPreviewLength;
-    }
-
-    const short = `${text.slice(0, cut).trim()}…`;
-    const more = text.slice(cut).trim();
-    return { short, more };
   }
 }


### PR DESCRIPTION
### Motivation
- La lista de tarifas era fácil de leer pero no orientaba a la decisión: demasiado texto en mobile y sin una acción clara por ítem. 
- Necesitábamos reducir el ruido de descripciones largas, facilitar la comparación de precios y conectar la elección directamente con el flujo de `Solicitar cita`. 
- La solución debía ser incremental, respetar la estética CBM y evitar modales o rediseños grandes. 

### Description
- Hice cada ítem de la lista accionable cambiando la plantilla de `pricing` para que el item sea un botón y muestre una micro-CTA `Elegir y solicitar cita →`, y añadí la clase/estado `selectedItemId` para el feedback visual; cambios en `src/app/sections/pricing/pricing.component.html` y `src/app/sections/pricing/pricing.component.css`. 
- Introduje previsualización de descripciones largas y expansión inline: en `pricing.component.ts` se calcula `microtextShort` y `hasLongDescription`, hay `toggleDetails(itemId)` e `isItemExpanded(itemId)` para `Ver detalles / Ocultar detalles` sin modal, y la plantilla muestra el resumen por defecto y expande solo cuando el usuario lo solicita. 
- Conecté la selección con el booking flow usando navegación con query params (`/solicitar-cita?tratamiento=<id>&paso=2`) desde `selectAndBook(item)` en `pricing.component.ts`, manteniendo el CTA general intacto como alternativa. 
- En el formulario de reserva actualicé `booking-form` para leer `tratamiento` y `paso` desde `ActivatedRoute`, preseleccionar la opción y avanzar a paso 2 cuando procede, además muestro un bloque inline con el tratamiento elegido en el paso de datos; archivos cambiados: `src/app/features/booking-form/booking-form.ts`, `booking-form.html`, `booking-form.css`. 

### Testing
- Ejecuté la compilación de la app con `npm run build` y el build completó correctamente. 
- La compilación mostró advertencias de presupuesto (`bundle/budgets`) que ya existían en el proyecto, no introducidas por estos cambios. 
- No se ejecutaron pruebas unitarias automáticas adicionales en este PR (solo build estático verificado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e308cdd9808328ba4830a7114f45a4)