### PR TITLE
feat: add Filosofía CBM editorial page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { AdminDashboardComponent } from './admin/admin-dashboard.component';
 import { RegaloComponent } from './features/regalo/regalo.component';
 import { CanjearRegaloComponent } from './canjear/canjear-regalo.component';
 import { BajaNewsletterComponent } from './features/baja-newsletter/baja-newsletter.component';
+import { FilosofiaCbmPage } from './features/filosofia-cbm/filosofia-cbm-page';
 
 export const routes: Routes = [
   {
@@ -35,6 +36,10 @@ export const routes: Routes = [
   {
     path: 'espacio-cbm',
     component: EspacioCbmPage
+  },
+  {
+    path: 'filosofia-cbm',
+    component: FilosofiaCbmPage
   },
   {
     path: 'blog',

--- a/src/app/core/header/header.html
+++ b/src/app/core/header/header.html
@@ -12,6 +12,7 @@
       <a *ngIf="showBonosRegalo" routerLink="/regalo">🎁 Bonos regalo</a>
       <a routerLink="/" fragment="contacto">Contáctanos</a>
       <a routerLink="/espacio-cbm">Espacio CBM</a>
+      <a routerLink="/filosofia-cbm">Filosofía CBM</a>
       <a routerLink="/blog">Blog</a>
     </nav>
 
@@ -54,6 +55,7 @@
       <a *ngIf="showBonosRegalo" routerLink="/regalo" (click)="closeMobileMenu()">🎁 Bonos regalo</a>
       <a routerLink="/" fragment="contacto" (click)="closeMobileMenu()">Contáctanos</a>
       <a routerLink="/espacio-cbm" (click)="closeMobileMenu()">Espacio CBM</a>
+      <a routerLink="/filosofia-cbm" (click)="closeMobileMenu()">Filosofía CBM</a>
       <a routerLink="/blog" (click)="closeMobileMenu()">Blog</a>
 
       <div class="mobile-language-group" role="group" aria-label="Language selector">

--- a/src/app/features/filosofia-cbm/filosofia-cbm-page.css
+++ b/src/app/features/filosofia-cbm/filosofia-cbm-page.css
@@ -7,6 +7,22 @@
   max-width: 900px;
 }
 
+
+.filosofia-page .reveal {
+  opacity: 0;
+  transform: translate3d(0, 16px, 0);
+  filter: none;
+  transition:
+    opacity 0.64s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.68s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform;
+}
+
+.filosofia-page .reveal.is-visible {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
 .filosofia-hero {
   padding: clamp(86px, 11vw, 134px) 0 clamp(70px, 8vw, 96px);
   text-align: center;
@@ -57,8 +73,8 @@
 .filosofia-cta p {
   margin: 0;
   color: var(--color-text);
-  font-size: clamp(1.04rem, 2vw, 1.17rem);
-  line-height: 1.88;
+  font-size: clamp(1.03rem, 1.7vw, 1.13rem);
+  line-height: 1.86;
   text-wrap: pretty;
 }
 
@@ -73,7 +89,7 @@
 .filosofia-diferencial h2,
 .filosofia-cierre h2 {
   margin: 0 0 14px;
-  font-size: clamp(1.74rem, 3.6vw, 2.58rem);
+  font-size: clamp(1.7rem, 3.4vw, 2.5rem);
   line-height: 1.17;
   letter-spacing: -0.022em;
   color: var(--color-dark);
@@ -118,7 +134,7 @@
 .pilar-item h3 {
   margin: 0;
   max-width: 18ch;
-  font-size: clamp(1.14rem, 2.2vw, 1.3rem);
+  font-size: clamp(1.12rem, 2.1vw, 1.26rem);
   line-height: 1.3;
   letter-spacing: -0.015em;
 }
@@ -127,7 +143,7 @@
   margin: 8px 0 0;
   max-width: 30ch;
   color: var(--color-muted);
-  line-height: 1.7;
+  line-height: 1.68;
 }
 
 .filosofia-cierre {
@@ -150,8 +166,8 @@
   color: #342f45;
   font-style: italic;
   font-weight: 500;
-  font-size: clamp(1.5rem, 3.7vw, 2.34rem);
-  line-height: 1.28;
+  font-size: clamp(1.56rem, 3.9vw, 2.46rem);
+  line-height: 1.24;
   letter-spacing: -0.014em;
 }
 
@@ -229,5 +245,15 @@
   .filosofia-quote blockquote {
     padding-left: 18px;
     max-width: 16ch;
+  }
+}
+
+
+@media (prefers-reduced-motion: reduce) {
+  .filosofia-page .reveal,
+  .filosofia-page .reveal.is-visible {
+    opacity: 1;
+    transform: none;
+    transition: none;
   }
 }

--- a/src/app/features/filosofia-cbm/filosofia-cbm-page.css
+++ b/src/app/features/filosofia-cbm/filosofia-cbm-page.css
@@ -1,0 +1,212 @@
+.filosofia-page {
+  position: relative;
+  padding: clamp(36px, 6vw, 78px) 0 clamp(90px, 10vw, 132px);
+}
+
+.filosofia-shell {
+  max-width: 860px;
+}
+
+.section {
+  padding: clamp(52px, 8vw, 90px) 0;
+}
+
+.filosofia-hero {
+  padding-top: clamp(74px, 9vw, 120px);
+  text-align: center;
+}
+
+.filosofia-eyebrow {
+  margin: 0 0 16px;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--color-secondary);
+}
+
+.filosofia-hero h1 {
+  margin: 0 auto;
+  max-width: 16ch;
+  font-size: clamp(2.15rem, 6vw, 4rem);
+  line-height: 1.08;
+  letter-spacing: -0.03em;
+  text-wrap: balance;
+}
+
+.filosofia-subtitle {
+  margin: 24px auto 0;
+  max-width: 40ch;
+  color: var(--color-muted);
+  font-size: clamp(1.02rem, 2.2vw, 1.26rem);
+  line-height: 1.72;
+}
+
+.filosofia-block,
+.filosofia-diferencial,
+.filosofia-cierre,
+.filosofia-cta {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.filosofia-block {
+  border-top: 1px solid rgba(123, 77, 255, 0.14);
+}
+
+.filosofia-block p,
+.filosofia-diferencial p,
+.filosofia-cierre p,
+.filosofia-cta p {
+  margin: 0;
+  color: var(--color-text);
+  font-size: clamp(1.04rem, 2vw, 1.2rem);
+  line-height: 1.9;
+  text-wrap: pretty;
+}
+
+.filosofia-block p + p {
+  margin-top: 24px;
+}
+
+.filosofia-diferencial {
+  padding-top: clamp(42px, 7vw, 72px);
+}
+
+.filosofia-diferencial h2,
+.filosofia-cierre h2 {
+  margin: 0 0 14px;
+  font-size: clamp(1.7rem, 3.6vw, 2.6rem);
+  line-height: 1.18;
+  letter-spacing: -0.02em;
+  color: var(--color-dark);
+  max-width: 20ch;
+}
+
+.filosofia-pilares {
+  padding-top: clamp(42px, 7vw, 72px);
+}
+
+.filosofia-pilares h2 {
+  margin: 0 0 34px;
+  font-size: clamp(1.52rem, 3vw, 2rem);
+  line-height: 1.22;
+  letter-spacing: -0.02em;
+  color: var(--color-dark);
+}
+
+.pilares-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.pilar-item {
+  padding: 18px 0;
+  border-top: 1px solid rgba(123, 77, 255, 0.16);
+}
+
+.pilar-item:last-child {
+  border-bottom: 1px solid rgba(123, 77, 255, 0.16);
+}
+
+.pilar-icon {
+  margin: 0 0 8px;
+  font-size: 1.45rem;
+  line-height: 1;
+}
+
+.pilar-item h3 {
+  margin: 0;
+  font-size: clamp(1.15rem, 2.2vw, 1.34rem);
+  line-height: 1.3;
+  letter-spacing: -0.015em;
+}
+
+.pilar-item p {
+  margin: 8px 0 0;
+  color: var(--color-muted);
+  line-height: 1.72;
+}
+
+.filosofia-cierre h2 {
+  max-width: 17ch;
+}
+
+.filosofia-quote {
+  max-width: 680px;
+  margin: 0 auto;
+  padding-top: clamp(38px, 6vw, 68px);
+}
+
+.filosofia-quote blockquote {
+  margin: 0;
+  padding-left: 20px;
+  border-left: 2px solid rgba(123, 77, 255, 0.34);
+  color: #423c55;
+  font-style: italic;
+  font-size: clamp(1.38rem, 3.5vw, 2.18rem);
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+}
+
+.filosofia-cta {
+  padding-top: clamp(40px, 6vw, 70px);
+  text-align: center;
+}
+
+.filosofia-cta p {
+  margin: 0 auto 24px;
+  max-width: 44ch;
+}
+
+.filosofia-cta .btn-primary {
+  min-width: 188px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (min-width: 760px) {
+  .pilares-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 34px;
+  }
+
+  .pilar-item,
+  .pilar-item:last-child {
+    border-top: none;
+    border-bottom: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .filosofia-hero {
+    text-align: left;
+  }
+
+  .filosofia-hero h1,
+  .filosofia-subtitle {
+    margin-left: 0;
+  }
+
+  .filosofia-hero h1 {
+    max-width: 14ch;
+  }
+
+  .filosofia-block p,
+  .filosofia-diferencial p,
+  .filosofia-cierre p,
+  .filosofia-cta p,
+  .pilar-item p {
+    line-height: 1.82;
+  }
+}

--- a/src/app/features/filosofia-cbm/filosofia-cbm-page.css
+++ b/src/app/features/filosofia-cbm/filosofia-cbm-page.css
@@ -1,18 +1,14 @@
 .filosofia-page {
   position: relative;
-  padding: clamp(36px, 6vw, 78px) 0 clamp(90px, 10vw, 132px);
+  padding: clamp(24px, 4vw, 56px) 0 clamp(92px, 10vw, 136px);
 }
 
 .filosofia-shell {
-  max-width: 860px;
-}
-
-.section {
-  padding: clamp(52px, 8vw, 90px) 0;
+  max-width: 900px;
 }
 
 .filosofia-hero {
-  padding-top: clamp(74px, 9vw, 120px);
+  padding: clamp(86px, 11vw, 134px) 0 clamp(70px, 8vw, 96px);
   text-align: center;
 }
 
@@ -28,30 +24,31 @@
 .filosofia-hero h1 {
   margin: 0 auto;
   max-width: 16ch;
-  font-size: clamp(2.15rem, 6vw, 4rem);
+  font-size: clamp(2.15rem, 6vw, 4.05rem);
   line-height: 1.08;
-  letter-spacing: -0.03em;
+  letter-spacing: -0.032em;
   text-wrap: balance;
 }
 
 .filosofia-subtitle {
-  margin: 24px auto 0;
-  max-width: 40ch;
+  margin: 26px auto 0;
+  max-width: 36ch;
   color: var(--color-muted);
-  font-size: clamp(1.02rem, 2.2vw, 1.26rem);
-  line-height: 1.72;
+  font-size: clamp(1.02rem, 2.2vw, 1.24rem);
+  line-height: 1.74;
 }
 
 .filosofia-block,
 .filosofia-diferencial,
 .filosofia-cierre,
-.filosofia-cta {
-  max-width: 680px;
+.filosofia-cta,
+.filosofia-quote {
+  max-width: 700px;
   margin: 0 auto;
 }
 
 .filosofia-block {
-  border-top: 1px solid rgba(123, 77, 255, 0.14);
+  padding: clamp(12px, 2vw, 22px) 0 clamp(56px, 7vw, 78px);
 }
 
 .filosofia-block p,
@@ -60,36 +57,37 @@
 .filosofia-cta p {
   margin: 0;
   color: var(--color-text);
-  font-size: clamp(1.04rem, 2vw, 1.2rem);
-  line-height: 1.9;
+  font-size: clamp(1.04rem, 2vw, 1.17rem);
+  line-height: 1.88;
   text-wrap: pretty;
 }
 
 .filosofia-block p + p {
-  margin-top: 24px;
+  margin-top: 26px;
 }
 
 .filosofia-diferencial {
-  padding-top: clamp(42px, 7vw, 72px);
+  padding: 0 0 clamp(64px, 8vw, 94px);
 }
 
 .filosofia-diferencial h2,
 .filosofia-cierre h2 {
   margin: 0 0 14px;
-  font-size: clamp(1.7rem, 3.6vw, 2.6rem);
-  line-height: 1.18;
-  letter-spacing: -0.02em;
+  font-size: clamp(1.74rem, 3.6vw, 2.58rem);
+  line-height: 1.17;
+  letter-spacing: -0.022em;
   color: var(--color-dark);
   max-width: 20ch;
+  text-wrap: balance;
 }
 
 .filosofia-pilares {
-  padding-top: clamp(42px, 7vw, 72px);
+  padding: 0 0 clamp(72px, 9vw, 104px);
 }
 
 .filosofia-pilares h2 {
-  margin: 0 0 34px;
-  font-size: clamp(1.52rem, 3vw, 2rem);
+  margin: 0 0 30px;
+  font-size: clamp(1.5rem, 3vw, 1.95rem);
   line-height: 1.22;
   letter-spacing: -0.02em;
   color: var(--color-dark);
@@ -97,35 +95,43 @@
 
 .pilares-grid {
   display: grid;
-  gap: 18px;
+  gap: 14px;
 }
 
 .pilar-item {
-  padding: 18px 0;
-  border-top: 1px solid rgba(123, 77, 255, 0.16);
-}
-
-.pilar-item:last-child {
-  border-bottom: 1px solid rgba(123, 77, 255, 0.16);
+  padding: 16px 0;
 }
 
 .pilar-icon {
-  margin: 0 0 8px;
-  font-size: 1.45rem;
+  width: 34px;
+  height: 34px;
+  margin: 0 0 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.05rem;
   line-height: 1;
+  border-radius: 999px;
+  background: linear-gradient(145deg, rgba(123, 77, 255, 0.12), rgba(255, 79, 163, 0.1));
 }
 
 .pilar-item h3 {
   margin: 0;
-  font-size: clamp(1.15rem, 2.2vw, 1.34rem);
+  max-width: 18ch;
+  font-size: clamp(1.14rem, 2.2vw, 1.3rem);
   line-height: 1.3;
   letter-spacing: -0.015em;
 }
 
 .pilar-item p {
   margin: 8px 0 0;
+  max-width: 30ch;
   color: var(--color-muted);
-  line-height: 1.72;
+  line-height: 1.7;
+}
+
+.filosofia-cierre {
+  padding: 0 0 clamp(58px, 8vw, 88px);
 }
 
 .filosofia-cierre h2 {
@@ -133,30 +139,29 @@
 }
 
 .filosofia-quote {
-  max-width: 680px;
-  margin: 0 auto;
-  padding-top: clamp(38px, 6vw, 68px);
+  padding: 0 0 clamp(60px, 7vw, 84px);
 }
 
 .filosofia-quote blockquote {
   margin: 0;
-  padding-left: 20px;
-  border-left: 2px solid rgba(123, 77, 255, 0.34);
-  color: #423c55;
+  max-width: 18ch;
+  padding-left: 24px;
+  border-left: 2px solid rgba(123, 77, 255, 0.42);
+  color: #342f45;
   font-style: italic;
-  font-size: clamp(1.38rem, 3.5vw, 2.18rem);
-  line-height: 1.35;
-  letter-spacing: -0.01em;
+  font-weight: 500;
+  font-size: clamp(1.5rem, 3.7vw, 2.34rem);
+  line-height: 1.28;
+  letter-spacing: -0.014em;
 }
 
 .filosofia-cta {
-  padding-top: clamp(40px, 6vw, 70px);
   text-align: center;
 }
 
 .filosofia-cta p {
   margin: 0 auto 24px;
-  max-width: 44ch;
+  max-width: 40ch;
 }
 
 .filosofia-cta .btn-primary {
@@ -178,19 +183,22 @@
 @media (min-width: 760px) {
   .pilares-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 34px;
+    gap: 38px;
   }
 
-  .pilar-item,
-  .pilar-item:last-child {
-    border-top: none;
-    border-bottom: none;
+  .pilar-item {
+    padding: 0;
   }
 }
 
 @media (max-width: 640px) {
+  .filosofia-page {
+    padding-top: 8px;
+  }
+
   .filosofia-hero {
     text-align: left;
+    padding-bottom: 58px;
   }
 
   .filosofia-hero h1,
@@ -202,11 +210,24 @@
     max-width: 14ch;
   }
 
+  .filosofia-block,
+  .filosofia-diferencial,
+  .filosofia-pilares,
+  .filosofia-cierre,
+  .filosofia-quote {
+    padding-bottom: 52px;
+  }
+
   .filosofia-block p,
   .filosofia-diferencial p,
   .filosofia-cierre p,
   .filosofia-cta p,
   .pilar-item p {
     line-height: 1.82;
+  }
+
+  .filosofia-quote blockquote {
+    padding-left: 18px;
+    max-width: 16ch;
   }
 }

--- a/src/app/features/filosofia-cbm/filosofia-cbm-page.html
+++ b/src/app/features/filosofia-cbm/filosofia-cbm-page.html
@@ -1,18 +1,18 @@
 <section class="filosofia-page">
   <div class="container filosofia-shell">
     <header class="filosofia-hero section">
-      <p class="filosofia-eyebrow">Filosofía CBM</p>
-      <h1>
+      <p class="filosofia-eyebrow reveal-delay-1" appRevealOnScroll>Filosofía CBM</p>
+      <h1 class="reveal-delay-2" appRevealOnScroll>
         Cuidamos tu cuerpo,<br>
         pero también entendemos tu proceso.
       </h1>
-      <p class="filosofia-subtitle">
+      <p class="filosofia-subtitle reveal-delay-3" appRevealOnScroll>
         Fisioterapia pensada para acompañarte,<br>
         no solo para resolver una molestia puntual.
       </p>
     </header>
 
-    <section class="filosofia-block section" aria-labelledby="conexion-title">
+    <section class="filosofia-block section reveal-delay-1" aria-labelledby="conexion-title" appRevealOnScroll>
       <h2 id="conexion-title" class="visually-hidden">Cómo trabajamos en CBM</h2>
       <p>Cada persona llega con una historia.</p>
       <p>Con un dolor,<br>una preocupación<br>o algo que quiere mejorar.</p>
@@ -22,7 +22,7 @@
       </p>
     </section>
 
-    <section class="filosofia-diferencial section" aria-labelledby="diferencial-title">
+    <section class="filosofia-diferencial section reveal-delay-1" aria-labelledby="diferencial-title" appRevealOnScroll>
       <h2 id="diferencial-title">No buscamos solo aliviar el síntoma.</h2>
       <p>
         Buscamos entender el origen,<br>
@@ -32,21 +32,21 @@
     </section>
 
     <section class="filosofia-pilares section" aria-labelledby="pilares-title">
-      <h2 id="pilares-title">3 pilares de nuestro enfoque</h2>
+      <h2 id="pilares-title" class="reveal-delay-1" appRevealOnScroll>3 pilares de nuestro enfoque</h2>
       <div class="pilares-grid">
-        <article class="pilar-item">
+        <article class="pilar-item reveal-delay-1" appRevealOnScroll>
           <p class="pilar-icon" aria-hidden="true">🤲</p>
           <h3>Terapia manual</h3>
           <p>Para aliviar el dolor y mejorar la movilidad desde el primer momento.</p>
         </article>
 
-        <article class="pilar-item">
+        <article class="pilar-item reveal-delay-2" appRevealOnScroll>
           <p class="pilar-icon" aria-hidden="true">🧠</p>
           <h3>Educación sobre el dolor</h3>
           <p>Para que entiendas qué ocurre en tu cuerpo y ganes seguridad.</p>
         </article>
 
-        <article class="pilar-item">
+        <article class="pilar-item reveal-delay-3" appRevealOnScroll>
           <p class="pilar-icon" aria-hidden="true">🏃</p>
           <h3>Ejercicio terapéutico</h3>
           <p>Para consolidar la mejora y evitar que el problema vuelva.</p>
@@ -54,7 +54,7 @@
       </div>
     </section>
 
-    <section class="filosofia-cierre section" aria-labelledby="cierre-title">
+    <section class="filosofia-cierre section reveal-delay-1" aria-labelledby="cierre-title" appRevealOnScroll>
       <h2 id="cierre-title">
         No se trata solo de sentirte mejor hoy.
       </h2>
@@ -65,14 +65,14 @@
       </p>
     </section>
 
-    <section class="filosofia-quote section" aria-label="Frase final">
+    <section class="filosofia-quote section reveal-delay-2" aria-label="Frase final" appRevealOnScroll>
       <blockquote>
         Cuidarte no es un momento.<br>
         Es un proceso.
       </blockquote>
     </section>
 
-    <section class="filosofia-cta section" aria-labelledby="cta-title">
+    <section class="filosofia-cta section reveal-delay-2" aria-labelledby="cta-title" appRevealOnScroll>
       <p id="cta-title">Si te has visto reflejado en esta forma de trabajar, podemos ayudarte.</p>
       <a routerLink="/solicitar-cita" class="btn-primary btn-booking">Solicitar cita</a>
     </section>

--- a/src/app/features/filosofia-cbm/filosofia-cbm-page.html
+++ b/src/app/features/filosofia-cbm/filosofia-cbm-page.html
@@ -1,0 +1,80 @@
+<section class="filosofia-page">
+  <div class="container filosofia-shell">
+    <header class="filosofia-hero section">
+      <p class="filosofia-eyebrow">Filosofía CBM</p>
+      <h1>
+        Cuidamos tu cuerpo,<br>
+        pero también entendemos tu proceso.
+      </h1>
+      <p class="filosofia-subtitle">
+        Fisioterapia pensada para acompañarte,<br>
+        no solo para resolver una molestia puntual.
+      </p>
+    </header>
+
+    <section class="filosofia-block section" aria-labelledby="conexion-title">
+      <h2 id="conexion-title" class="visually-hidden">Cómo trabajamos en CBM</h2>
+      <p>Cada persona llega con una historia.</p>
+      <p>Con un dolor,<br>una preocupación<br>o algo que quiere mejorar.</p>
+      <p>
+        Por eso en CBM no trabajamos con protocolos cerrados,<br>
+        sino con tratamientos que se adaptan a ti.
+      </p>
+    </section>
+
+    <section class="filosofia-diferencial section" aria-labelledby="diferencial-title">
+      <h2 id="diferencial-title">No buscamos solo aliviar el síntoma.</h2>
+      <p>
+        Buscamos entender el origen,<br>
+        acompañarte en el proceso<br>
+        y ayudarte a mejorar de forma real y duradera.
+      </p>
+    </section>
+
+    <section class="filosofia-pilares section" aria-labelledby="pilares-title">
+      <h2 id="pilares-title">3 pilares de nuestro enfoque</h2>
+      <div class="pilares-grid">
+        <article class="pilar-item">
+          <p class="pilar-icon" aria-hidden="true">🤲</p>
+          <h3>Terapia manual</h3>
+          <p>Para aliviar el dolor y mejorar la movilidad desde el primer momento.</p>
+        </article>
+
+        <article class="pilar-item">
+          <p class="pilar-icon" aria-hidden="true">🧠</p>
+          <h3>Educación sobre el dolor</h3>
+          <p>Para que entiendas qué ocurre en tu cuerpo y ganes seguridad.</p>
+        </article>
+
+        <article class="pilar-item">
+          <p class="pilar-icon" aria-hidden="true">🏃</p>
+          <h3>Ejercicio terapéutico</h3>
+          <p>Para consolidar la mejora y evitar que el problema vuelva.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="filosofia-cierre section" aria-labelledby="cierre-title">
+      <h2 id="cierre-title">
+        No se trata solo de sentirte mejor hoy.
+      </h2>
+      <p>
+        Se trata de que puedas moverte con confianza,<br>
+        sin miedo<br>
+        y con autonomía.
+      </p>
+    </section>
+
+    <section class="filosofia-quote section" aria-label="Frase final">
+      <blockquote>
+        Cuidarte no es un momento.<br>
+        Es un proceso.
+      </blockquote>
+    </section>
+
+    <section class="filosofia-cta section" aria-labelledby="cta-title">
+      <p id="cta-title">Si sientes que este enfoque encaja contigo, podemos ayudarte.</p>
+      <a routerLink="/solicitar-cita" class="btn-primary btn-booking">Solicitar cita</a>
+    </section>
+  </div>
+</section>

--- a/src/app/features/filosofia-cbm/filosofia-cbm-page.html
+++ b/src/app/features/filosofia-cbm/filosofia-cbm-page.html
@@ -73,7 +73,7 @@
     </section>
 
     <section class="filosofia-cta section" aria-labelledby="cta-title">
-      <p id="cta-title">Si sientes que este enfoque encaja contigo, podemos ayudarte.</p>
+      <p id="cta-title">Si te has visto reflejado en esta forma de trabajar, podemos ayudarte.</p>
       <a routerLink="/solicitar-cita" class="btn-primary btn-booking">Solicitar cita</a>
     </section>
   </div>

--- a/src/app/features/filosofia-cbm/filosofia-cbm-page.ts
+++ b/src/app/features/filosofia-cbm/filosofia-cbm-page.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-filosofia-cbm-page',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './filosofia-cbm-page.html',
+  styleUrl: './filosofia-cbm-page.css'
+})
+export class FilosofiaCbmPage {}

--- a/src/app/features/filosofia-cbm/filosofia-cbm-page.ts
+++ b/src/app/features/filosofia-cbm/filosofia-cbm-page.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { RevealOnScrollDirective } from '../../shared/directives/reveal-on-scroll.directive';
 
 @Component({
   selector: 'app-filosofia-cbm-page',
   standalone: true,
-  imports: [RouterLink],
+  imports: [RouterLink, RevealOnScrollDirective],
   templateUrl: './filosofia-cbm-page.html',
   styleUrl: './filosofia-cbm-page.css'
 })


### PR DESCRIPTION
### Motivation
- Crear una nueva página editorial y premium llamada `Filosofía CBM` que transmita confianza, explique el enfoque de trabajo y conecte emocionalmente sin romper el estilo visual existente. 
- Mantener una estética ligera y mobile-first, evitando componentes pesados, modales o lenguaje comercial agresivo.

### Description
- Añadido un componente standalone `FilosofiaCbmPage` con HTML semántico en `src/app/features/filosofia-cbm/filosofia-cbm-page.html` que implementa las secciones solicitadas (HERO, bloque de texto, diferencial, 3 pilares, cierre emocional, cita y CTA) usando exactamente el copy proporcionado. 
- Estilos SCSS responsive y mobile-first en `src/app/features/filosofia-cbm/filosofia-cbm-page.css` con foco en mucho espacio vertical, line-height cómodo, `max-width` para lectura y bloques ligeros coherentes con las variables globales de diseño. 
- Registro de la ruta en `src/app/app.routes.ts` (`/filosofia-cbm`) y añadida entrada de navegación en desktop y móvil en `src/app/core/header/header.html` para que la página sea accesible desde el menú. 
- Accesibilidad básica añadida con encabezado oculto para screen readers (`.visually-hidden`) y uso de `RouterLink` y botones existentes (`.btn-primary`) sin librerías externas.

### Testing
- Ejecutado `npm run build` y la compilación finalizó correctamente sin errores de compilación. 
- Aparecieron advertencias de presupuesto de bundle ya existentes en el proyecto, las cuales no bloquean la build. 
- No se ejecutaron tests E2E/Unit porque no forman parte de este cambio; sólo se validó la construcción del proyecto (build successful).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e31b09608883288ff04d4e3acd486b)