### PR TITLE
Corregir canonical y og:url por ruta (CanonicalService) y eliminar canonical global

### DIFF
--- a/src/app/core/seo/canonical.service.ts
+++ b/src/app/core/seo/canonical.service.ts
@@ -12,9 +12,9 @@ export class CanonicalService {
     '/': 'CBM Fisioterapia · Fisioterapia y Pilates en Terrassa',
     '/experiencia': 'Nuestra experiencia · CBM Fisioterapia',
     '/tratamientos': 'Tratamientos · CBM Fisioterapia',
-    '/tratamientos/fisioterapia': 'Fisioterapia en Terrassa · CBM Fisioterapia',
-    '/tratamientos/tecnicas': 'Técnicas utilizadas · CBM Fisioterapia',
-    '/tratamientos/pilates': 'Pilates terapéutico en Terrassa · CBM Fisioterapia',
+    '/tratamientos/fisioterapia': 'Fisioterapia en Terrassa | CBM Fisioterapia',
+    '/tratamientos/tecnicas': 'Técnicas utilizadas en Terrassa | CBM Fisioterapia',
+    '/tratamientos/pilates': 'Pilates en Terrassa | CBM Fisioterapia',
     '/tarifas': 'Tarifas y bonos · CBM Fisioterapia',
     '/solicitar-cita': 'Solicitar cita · CBM Fisioterapia',
     '/faq': 'Preguntas frecuentes · CBM Fisioterapia',
@@ -33,16 +33,11 @@ export class CanonicalService {
   ) {}
 
   updateFromUrl(url: string): void {
-    const canonicalHref = this.buildCanonicalHref(url);
+    const cleanPath = this.normalizePath(url);
+    const canonicalHref = this.buildCanonicalHref(cleanPath);
+
     this.ensureSingleCanonicalTag(canonicalHref);
-
     this.meta.updateTag({ property: 'og:url', content: canonicalHref });
-
-    const [pathWithoutQuery] = url.split(/[?#]/);
-    const cleanPath =
-      pathWithoutQuery === '/' || pathWithoutQuery === ''
-        ? '/'
-        : pathWithoutQuery.replace(/\/+$/, '');
 
     this.titleService.setTitle(this.routeTitles[cleanPath] ?? this.defaultTitle);
 
@@ -53,34 +48,31 @@ export class CanonicalService {
     }
   }
 
-  private buildCanonicalHref(url: string): string {
-    const [pathWithoutQuery] = url.split(/[?#]/);
-    const normalizedPath =
-      pathWithoutQuery === '/' || pathWithoutQuery === ''
-        ? '/'
-        : pathWithoutQuery.replace(/\/+$/, '');
+  private normalizePath(url: string): string {
+    const parsedUrl = new URL(url, this.siteUrl);
+    const withoutDuplicateSlashes = parsedUrl.pathname.replace(/\/+/g, '/');
 
-    return normalizedPath === '/'
+    if (withoutDuplicateSlashes === '' || withoutDuplicateSlashes === '/') {
+      return '/';
+    }
+
+    return withoutDuplicateSlashes.replace(/\/+$/, '');
+  }
+
+  private buildCanonicalHref(cleanPath: string): string {
+    return cleanPath === '/'
       ? `${this.siteUrl}/`
-      : `${this.siteUrl}${normalizedPath}`;
+      : `${this.siteUrl}${cleanPath}`;
   }
 
   private ensureSingleCanonicalTag(href: string): void {
-    const canonicalTags = Array.from(
-      this.document.querySelectorAll<HTMLLinkElement>('link[rel="canonical"]')
-    );
-    const [firstCanonicalTag, ...duplicateCanonicalTags] = canonicalTags;
+    const canonicalTags = this.document.querySelectorAll<HTMLLinkElement>('link[rel="canonical"]');
 
-    for (const duplicateTag of duplicateCanonicalTags) {
-      duplicateTag.remove();
-    }
+    canonicalTags.forEach((tag) => tag.remove());
 
-    const canonicalTag = firstCanonicalTag ?? this.document.createElement('link');
+    const canonicalTag = this.document.createElement('link');
     canonicalTag.setAttribute('rel', 'canonical');
     canonicalTag.setAttribute('href', href);
-
-    if (!firstCanonicalTag) {
-      this.document.head.appendChild(canonicalTag);
-    }
+    this.document.head.appendChild(canonicalTag);
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -32,7 +32,6 @@
   <meta name="apple-mobile-web-app-title" content="CBM Fisio">
   <meta name="apple-mobile-web-app-capable" content="yes">
 
-  <link rel="canonical" href="https://cbmfisioterapia.com">
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">


### PR DESCRIPTION
### Motivation
- Evitar que la canonical fija en `index.html` fuerce la home como canónica para todas las rutas de la SPA y haga que páginas internas sean tratadas como "alternativas" por Google.
- Garantizar que cada página pública tenga su canonical autorefenciada y que `og:url` refleje la misma URL para evitar inconsistencias SEO.
- Mantener la política de indexación para páginas privadas (`/admin`) usando `robots: noindex, nofollow`.

### Description
- Eliminé la etiqueta canonical fija en `src/index.html` para no imponer la home como canonical global.
- Refactoricé `src/app/core/seo/canonical.service.ts` para normalizar rutas con `new URL(...)`, eliminar query params y fragments, colapsar slashes duplicados y quitar slash final en rutas internas, y generar la home como `https://cbmfisioterapia.com/`.
- Hice determinista la manipulación de la etiqueta canonical eliminando cualquier `link[rel="canonical"]` existente y añadiendo una única etiqueta actualizada en cada `updateFromUrl(...)`.
- Sincronizo `og:url` con la canonical generada y mantengo la lógica de `robots` (noindex para `/admin`, index para público) y el `title` por ruta usando el mapa de títulos existente; ajusté algunos títulos de tratamientos para alinear estilo.
- Verifiqué que el servicio se invoca en carga inicial y en cada cambio de ruta porque ya está conectado al hook de `NavigationEnd` en `src/app/app.ts`.

### Testing
- Ejecuté la compilación con `npm run build` y la construcción finalizó correctamente (warnings existentes de budgets, sin errores).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e673450a1083289c71b21798c1d9f0)