### PR TITLE
Añadir paso de pago presencial al flujo de solicitud de cita

### DIFF
--- a/prompts/frontend/SPEC-003-booking-payment-step/plan.md
+++ b/prompts/frontend/SPEC-003-booking-payment-step/plan.md
@@ -1,0 +1,33 @@
+# Plan — SPEC-003 Paso intermedio de pago
+
+## Capa afectada
+
+Frontend Angular standalone.
+
+## Archivos a modificar
+
+| Archivo                                           | Cambio                                                                                                            |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `src/app/features/booking-form/booking-form.ts`   | Ajustar navegación del stepper de 2 a 3 pasos, añadir guardas para pago y Calendly, mantener selección al volver. |
+| `src/app/features/booking-form/booking-form.html` | Actualizar stepper visual, insertar paso “Pago” y mover Calendly al paso 3.                                       |
+| `src/app/features/booking-form/booking-form.css`  | Añadir estilos responsive para resumen de pago y forma de pago con estética CBM.                                  |
+
+## Decisiones técnicas
+
+1. Se conserva `formData.treatment` como fuente local del tratamiento elegido.
+2. Se conserva `BookingTreatmentService` para propagar el tratamiento a `Step3CalendlyComponent` y mantener `prefill.customAnswers`.
+3. No se añade formulario de pago ni estado seleccionable de método de pago; la card de pago presencial es informativa y queda preparada visualmente para futuras opciones.
+4. El paso “Fecha y hora” solo renderiza `app-step3-calendly` si existe `selectedTreatmentOption`.
+5. La preselección desde tarifas aterriza en el paso “Pago” para que el usuario confirme antes de ver Calendly.
+6. En móvil se mantiene el autoavance tras seleccionar tratamiento, pero ahora avanza a “Pago”.
+
+## Riesgos y mitigación
+
+- **Riesgo:** Saltar a Calendly sin tratamiento.  
+  **Mitigación:** `irAlPaso2()` y `irAlPaso3()` validan `canAdvanceStep1` y `canAdvancePayment`.
+
+- **Riesgo:** Perder la selección al volver.  
+  **Mitigación:** `prevStep()` solo decrementa el paso y no limpia el tratamiento seleccionado.
+
+- **Riesgo:** Romper Calendly.  
+  **Mitigación:** No se modifica `Step3CalendlyComponent`; solo cambia cuándo se renderiza.

--- a/prompts/frontend/SPEC-003-booking-payment-step/spec.md
+++ b/prompts/frontend/SPEC-003-booking-payment-step/spec.md
@@ -1,0 +1,66 @@
+# SPEC-003 — Paso intermedio de pago en solicitud de cita
+
+## Objetivo
+
+Modificar el flujo frontend de `/solicitar-cita` para añadir un paso intermedio informativo de pago entre la selección de tratamiento y el embed de Calendly.
+
+## Estado actual
+
+El stepper de solicitud de cita tiene 2 pasos:
+
+1. Tu tratamiento
+2. Fecha y hora
+
+Al continuar desde tratamientos, el usuario llega directamente al Calendly.
+
+## Estado objetivo
+
+El stepper debe tener 3 pasos:
+
+1. Tu tratamiento
+2. Pago
+3. Fecha y hora
+
+Antes de mostrar Calendly, el usuario debe revisar el tratamiento seleccionado, su precio y la forma de pago disponible actualmente: pago presencial en el centro.
+
+## Requisitos funcionales
+
+1. Mantener el tratamiento seleccionado en el estado actual del flujo.
+2. El botón “Continuar” del paso de tratamientos avanza al paso “Pago”.
+3. El paso “Pago” muestra:
+   - Nombre del tratamiento.
+   - Precio.
+   - Texto secundario del tratamiento si existe.
+   - Horarios/modalidad si existen para el tratamiento.
+4. El paso “Pago” muestra una card de forma de pago con:
+   - Título “Forma de pago”.
+   - Opción informativa seleccionada “Pago en el local”.
+   - Texto “El pago se realizará directamente en el centro el día de la cita.”
+5. No se muestran opciones de Stripe, tarjeta, Bizum ni pago online.
+6. El usuario no puede elegir otra forma de pago.
+7. El botón principal del paso “Pago” avanza al paso “Fecha y hora”.
+8. El botón “Atrás” respeta la navegación:
+   - Desde “Pago” vuelve a “Tu tratamiento”.
+   - Desde “Fecha y hora” vuelve a “Pago”.
+9. El stepper visual muestra los tres pasos.
+10. Si no hay tratamiento seleccionado, no se puede avanzar a “Pago” ni a “Fecha y hora”.
+11. Calendly sigue recibiendo el tratamiento seleccionado mediante `prefill.customAnswers`.
+12. No se manipula directamente el iframe de Calendly ni se rompe su integración.
+
+## Requisitos UX/UI
+
+- Mantener estética CBM: fondo claro, cards limpias, bordes redondeados, gradientes suaves rosa/violeta y sensación wellness/premium.
+- Diseño responsive desktop/mobile.
+- Copy principal del paso:
+  - Título: “Confirma tu tratamiento”
+  - Subtítulo: “Revisa el tratamiento seleccionado antes de elegir la fecha y hora.”
+  - Apoyo: “Recibirás la confirmación de tu cita por correo electrónico al finalizar la reserva.”
+  - Botón principal: “Continuar a fecha y hora →”
+  - Botón secundario: “← Atrás”
+
+## Fuera de alcance
+
+- Implementar pago online.
+- Añadir Stripe, tarjeta, Bizum u otras opciones seleccionables.
+- Cambiar la configuración de Calendly.
+- Modificar backend, Supabase o Netlify Functions.

--- a/prompts/frontend/SPEC-003-booking-payment-step/tasks.md
+++ b/prompts/frontend/SPEC-003-booking-payment-step/tasks.md
@@ -1,0 +1,9 @@
+# Tasks — SPEC-003 Paso intermedio de pago
+
+- [x] T003-FE-01 Actualizar navegación del stepper a 3 pasos en `booking-form.ts`.
+- [x] T003-FE-02 Cambiar la preselección desde tarifas para iniciar en el paso “Pago”.
+- [x] T003-FE-03 Actualizar el stepper visual con “Tu tratamiento”, “Pago” y “Fecha y hora”.
+- [x] T003-FE-04 Añadir template del paso “Pago” con resumen del tratamiento y forma de pago presencial.
+- [x] T003-FE-05 Mover Calendly al paso 3 y mantener guardas si no hay tratamiento.
+- [x] T003-FE-06 Añadir estilos responsive para cards de pago y resumen.
+- [x] T003-FE-07 Verificar build Angular.

--- a/prompts/quality/SPEC-003-booking-payment-step/plan.md
+++ b/prompts/quality/SPEC-003-booking-payment-step/plan.md
@@ -1,0 +1,11 @@
+# Plan Quality — SPEC-003 Paso intermedio de pago
+
+## Estrategia
+
+1. Ejecutar `npm run build` para validar TypeScript strict, templates Angular y bundling.
+2. Revisar estáticamente que `Step3CalendlyComponent` mantiene `prefill.customAnswers`.
+3. Revisar que el template solo renderiza Calendly con tratamiento seleccionado.
+
+## Limitaciones
+
+No se automatiza una prueba E2E contra Calendly porque depende de un servicio externo y de interacción con iframe de terceros.

--- a/prompts/quality/SPEC-003-booking-payment-step/spec.md
+++ b/prompts/quality/SPEC-003-booking-payment-step/spec.md
@@ -1,0 +1,20 @@
+# SPEC-003 Quality — Paso intermedio de pago
+
+## Objetivo de calidad
+
+Validar que el flujo de solicitud de cita incorpora el paso “Pago” sin romper selección de tratamiento ni Calendly.
+
+## Criterios de aceptación
+
+1. El proyecto compila sin errores TypeScript ni de templates Angular.
+2. El stepper muestra 3 pasos.
+3. El flujo correcto es: tratamiento → pago → fecha y hora.
+4. El botón atrás desde fecha y hora vuelve a pago.
+5. El botón atrás desde pago vuelve a tratamiento sin perder la selección visual.
+6. Si no hay tratamiento seleccionado, no se renderiza Calendly.
+7. El tratamiento seleccionado continúa disponible para `prefill.customAnswers` en Calendly.
+
+## Fuera de alcance
+
+- Tests end-to-end con Calendly real.
+- Validar configuración externa de preguntas custom en Calendly.

--- a/prompts/quality/SPEC-003-booking-payment-step/tasks.md
+++ b/prompts/quality/SPEC-003-booking-payment-step/tasks.md
@@ -1,0 +1,5 @@
+# Tasks Quality — SPEC-003 Paso intermedio de pago
+
+- [x] T003-QA-01 Ejecutar build Angular.
+- [x] T003-QA-02 Confirmar que Calendly sigue protegido por selección de tratamiento.
+- [x] T003-QA-03 Confirmar que `prefill.customAnswers` no se elimina ni modifica.

--- a/src/app/features/booking-form/booking-form.css
+++ b/src/app/features/booking-form/booking-form.css
@@ -333,6 +333,139 @@
   display: flex;
 }
 
+/* ── Payment confirmation (paso 2) ─────────────────────── */
+.payment-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.payment-summary-card,
+.payment-method-card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(241, 216, 230, 0.9);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 10px 24px rgba(31, 27, 45, 0.06);
+}
+
+.payment-summary-card::before,
+.payment-method-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(255, 79, 163, 0.09), rgba(168, 85, 247, 0.07));
+}
+
+.payment-summary-card {
+  padding: 22px;
+}
+
+.payment-method-card {
+  padding: 20px;
+}
+
+.payment-card-kicker {
+  position: relative;
+  z-index: 1;
+  margin: 0 0 12px;
+  color: #9a92a8;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.payment-summary-main {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+}
+
+.payment-summary-main h4,
+.payment-method-option h4 {
+  margin: 0;
+  color: #1f1b2d;
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.payment-summary-description {
+  margin: 8px 0 0;
+  color: #6e6780;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.payment-summary-price {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  min-width: 76px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  color: #7b2cbf;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(168, 85, 247, 0.16);
+  box-shadow: 0 8px 18px rgba(168, 85, 247, 0.1);
+  font-size: 17px;
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.payment-method-option {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  gap: 12px;
+  padding: 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1.5px solid transparent;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.88)) padding-box,
+    linear-gradient(135deg, rgba(244, 114, 182, 0.75), rgba(168, 85, 247, 0.7)) border-box;
+}
+
+.payment-method-check {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: white;
+  background: var(--gradient-brand);
+  box-shadow: 0 8px 18px rgba(123, 77, 255, 0.24);
+}
+
+.payment-method-option p {
+  margin: 6px 0 0;
+  color: #6e6780;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.payment-support-text {
+  margin: 0 0 18px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  color: #6e3050;
+  background: rgba(255, 79, 163, 0.07);
+  border: 1px solid rgba(255, 79, 163, 0.13);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
 /* ── Step actions ──────────────────────────────────────── */
 .tarifas-error {
   display: flex;
@@ -423,7 +556,7 @@
   border-color: #e05c7b !important;
 }
 
-/* ── Form fields (paso 2) ──────────────────────────────── */
+/* ── Form fields legacy ───────────────────────────────── */
 .form-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -515,7 +648,7 @@
   line-height: 1.45;
 }
 
-/* ── Summary card (paso 3) ─────────────────────────────── */
+/* ── Summary card legacy ──────────────────────────────── */
 .summary-card {
   background: rgba(255, 247, 251, 0.8);
   border: 1px solid rgba(241, 216, 230, 0.9);
@@ -714,7 +847,7 @@
   color: #047857;
 }
 
-/* ── Calendly widget (paso 2) ──────────────────────────── */
+/* ── Calendly widget (paso 3) ──────────────────────────── */
 .calendly-wrapper {
   margin-bottom: 16px;
 }
@@ -809,6 +942,25 @@
     grid-template-columns: 1fr;
   }
 
+  .payment-layout {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .payment-summary-card,
+  .payment-method-card {
+    padding: 16px;
+  }
+
+  .payment-summary-main {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .payment-summary-price {
+    align-self: flex-start;
+  }
+
   .form-grid {
     grid-template-columns: 1fr;
     gap: 0;
@@ -825,8 +977,13 @@
   }
 
   .step-actions--with-back {
-    flex-direction: row;
-    justify-content: space-between;
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .step-actions--with-back .step-btn-back {
+    align-self: center;
+    padding: 8px 0;
   }
 
   .promo-toggle {

--- a/src/app/features/booking-form/booking-form.html
+++ b/src/app/features/booking-form/booking-form.html
@@ -5,8 +5,8 @@
         <p class="section-tag">Solicitar cita</p>
         <h2>Elige tu tratamiento y solicita tu cita</h2>
         <p class="section-description">
-          Selecciona tu tratamiento y elige tu fecha y hora. Recibirás la confirmación
-          automáticamente. 💜
+          Selecciona tu tratamiento, confirma el pago en el local y elige tu fecha y hora. Recibirás
+          la confirmación automáticamente. 💜
         </p>
       </div>
 
@@ -51,9 +51,34 @@
 
           <div class="stepper-line" [class.stepper-line--filled]="currentStep > 1"></div>
 
-          <div class="stepper-step-item" [class.stepper-step-item--active]="currentStep === 2">
+          <div
+            class="stepper-step-item"
+            [class.stepper-step-item--active]="currentStep === 2"
+            [class.stepper-step-item--done]="currentStep > 2"
+          >
             <div class="stepper-circle">
-              <span>2</span>
+              <span *ngIf="currentStep <= 2">2</span>
+              <svg
+                *ngIf="currentStep > 2"
+                viewBox="0 0 24 24"
+                width="14"
+                height="14"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"
+                />
+              </svg>
+            </div>
+            <span class="stepper-label">Pago</span>
+          </div>
+
+          <div class="stepper-line" [class.stepper-line--filled]="currentStep > 2"></div>
+
+          <div class="stepper-step-item" [class.stepper-step-item--active]="currentStep === 3">
+            <div class="stepper-circle">
+              <span>3</span>
             </div>
             <span class="stepper-label">Fecha y hora</span>
           </div>
@@ -136,15 +161,81 @@
             </ng-container>
           </div>
 
-          <!-- Paso 2: Fecha y hora (Calendly) -->
+          <!-- Paso 2: Pago -->
           <div *ngIf="currentStep === 2" [class]="'stepper-pane ' + stepAnimClass">
+            <h3 class="step-title">Confirma tu tratamiento</h3>
+            <p class="step-subtitle">
+              Revisa el tratamiento seleccionado antes de elegir la fecha y hora.
+            </p>
+
+            <ng-container *ngIf="selectedTreatmentOption as selected; else noPaymentTreatment">
+              <div class="payment-layout">
+                <section class="payment-summary-card" aria-label="Tratamiento seleccionado">
+                  <p class="payment-card-kicker">Tratamiento seleccionado</p>
+                  <div class="payment-summary-main">
+                    <div>
+                      <h4>{{ selected.nombre }}</h4>
+                      <p *ngIf="selected.descripcion" class="payment-summary-description">
+                        {{ selected.descripcion }}
+                      </p>
+                      <app-horario-chips [horarios]="selected.horarios"></app-horario-chips>
+                    </div>
+                    <strong class="payment-summary-price">{{ selected.precio }}</strong>
+                  </div>
+                </section>
+
+                <section class="payment-method-card" aria-label="Forma de pago">
+                  <p class="payment-card-kicker">Forma de pago</p>
+                  <div class="payment-method-option" aria-current="true">
+                    <span class="payment-method-check" aria-hidden="true">
+                      <svg viewBox="0 0 24 24" width="16" height="16">
+                        <path
+                          fill="currentColor"
+                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"
+                        />
+                      </svg>
+                    </span>
+                    <div>
+                      <h4>Pago en el local</h4>
+                      <p>El pago se realizará directamente en el centro el día de la cita.</p>
+                    </div>
+                  </div>
+                </section>
+              </div>
+
+              <p class="payment-support-text">
+                Recibirás la confirmación de tu cita por correo electrónico al finalizar la reserva.
+              </p>
+
+              <div class="step-actions step-actions--with-back">
+                <button type="button" class="step-btn-back" (click)="prevStep()">← Atrás</button>
+                <button type="button" class="btn-primary step-btn-continue" (click)="irAlPaso3()">
+                  Continuar a fecha y hora →
+                </button>
+              </div>
+            </ng-container>
+
+            <ng-template #noPaymentTreatment>
+              <div class="no-treatment-warning">
+                <p>📋 Por favor, selecciona un tratamiento para continuar.</p>
+                <button type="button" class="step-btn-back" (click)="currentStep = 1">
+                  ← Volver a seleccionar
+                </button>
+              </div>
+            </ng-template>
+          </div>
+
+          <!-- Paso 3: Fecha y hora (Calendly) -->
+          <div *ngIf="currentStep === 3" [class]="'stepper-pane ' + stepAnimClass">
             <h3 class="step-title">Elige tu fecha y hora</h3>
             <p class="step-subtitle">Selecciona el momento que mejor te venga</p>
 
             <!-- Validación: mostrar si no hay tratamiento (por si acaso) -->
             <div *ngIf="!selectedTreatmentOption" class="no-treatment-warning">
               <p>📋 Por favor, selecciona un tratamiento para continuar.</p>
-              <button type="button" class="step-btn-back" (click)="prevStep()">← Volver a seleccionar</button>
+              <button type="button" class="step-btn-back" (click)="currentStep = 1">
+                ← Volver a seleccionar
+              </button>
             </div>
 
             <app-step3-calendly *ngIf="selectedTreatmentOption"></app-step3-calendly>

--- a/src/app/features/booking-form/booking-form.ts
+++ b/src/app/features/booking-form/booking-form.ts
@@ -49,7 +49,7 @@ interface TreatmentOption {
 export class BookingFormComponent implements OnInit {
   private readonly platformId = inject(PLATFORM_ID);
 
-   constructor(
+  constructor(
     private readonly tarifasService: TarifasService,
     private readonly cdr: ChangeDetectorRef,
     private readonly route: ActivatedRoute,
@@ -149,7 +149,11 @@ export class BookingFormComponent implements OnInit {
   }
 
   get canAdvanceStep1(): boolean {
-    return !!this.formData.treatment;
+    return !!this.selectedTreatmentOption;
+  }
+
+  get canAdvancePayment(): boolean {
+    return !!this.selectedTreatmentOption;
   }
 
   seleccionarTratamiento(option: TreatmentOption): void {
@@ -175,7 +179,7 @@ export class BookingFormComponent implements OnInit {
   }
 
   irAlPaso2(): void {
-    // Validación: si no hay tratamiento, no permitir avanzar
+    // Validación: si no hay tratamiento, no permitir avanzar al pago
     if (!this.canAdvanceStep1) {
       return;
     }
@@ -184,14 +188,21 @@ export class BookingFormComponent implements OnInit {
     this.scrollToForm();
   }
 
-  prevStep(): void {
-    if (this.currentStep === 2) {
-      this.bookingTreatmentService.clearSelectedTreatment();
-      if (this.preselectedFromPricing) {
-        this.preselectedFromPricing = false;
-        this.formData.treatment = '';
-      }
+  irAlPaso3(): void {
+    // Validación: si no hay tratamiento, no permitir mostrar Calendly
+    if (!this.canAdvancePayment) {
+      return;
     }
+    this.stepAnimClass = 'step-enter-forward';
+    this.currentStep = 3;
+    this.scrollToForm();
+  }
+
+  prevStep(): void {
+    if (this.currentStep <= 1) {
+      return;
+    }
+
     this.stepAnimClass = 'step-enter-back';
     this.currentStep--;
   }


### PR DESCRIPTION
### Motivation

- Añadir un paso intermedio que deje claro al usuario el tratamiento elegido y cómo se paga antes de mostrar el embed de Calendly. 
- Evitar confusión al saltar directamente a la selección de fecha y hora sin confirmar precio y forma de pago. 
- Preparar la UI para futuras opciones de pago online sin implementar ninguna pasarela ahora, mostrando solo “Pago en el local”.

### Description

- Actualiza el stepper en `booking-form` de 2 a 3 pasos y cambia la navegación para que el botón “Continuar” desde tratamientos avance a `Pago` y desde `Pago` a `Fecha y hora` (se añadieron `irAlPaso2()` y `irAlPaso3()` y guardas `canAdvancePayment`).
- Añade el template del paso `Pago` en `src/app/features/booking-form/booking-form.html` con card resumen del tratamiento, precio, descripción/horarios si existen y una card informativa de forma de pago con la opción fija “Pago en el local”.
- Introduce estilos responsive nuevos en `src/app/features/booking-form/booking-form.css` para mantener la estética CBM (fondo claro, cards limpias, bordes redondeados, gradientes rosa/violeta) en desktop y mobile.
- Mantiene la propagación del tratamiento a `Step3CalendlyComponent` vía `BookingTreatmentService` y `prefill.customAnswers`; no se toca el iframe ni se altera la integración de Calendly.
- Añade documentación SDD: `prompts/frontend/SPEC-003-booking-payment-step/*` y `prompts/quality/SPEC-003-booking-payment-step/*` con spec, plan y tasks.

### Testing

- Ejecutado `npm run build` y la compilación fue correcta; Angular emitió warnings de presupuesto CSS pero el build completó con éxito. 
- Ejecutado `npx prettier --check` sobre los archivos modificados y los nuevos `prompts/*` y pasó tras formateo automático. 
- Ejecutado `git diff --check` y verificación estática de cambios sin errores de chequeo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19786e3c688328902cbfe3c5cfc0d0)